### PR TITLE
feat: add responsive navbar with theme toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import { Navbar } from "@/components/navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +27,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        {children}
+        <ThemeProvider>
+          <Navbar />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { useThemeStore } from "@/store/theme";
+import {
+  FaUser,
+  FaListAlt,
+  FaTools,
+  FaFolderOpen,
+  FaEnvelope,
+  FaBars,
+  FaSun,
+  FaMoon,
+} from "react-icons/fa";
+
+const links = [
+  { href: "#about", label: "About", icon: FaUser },
+  { href: "#features", label: "Features", icon: FaListAlt },
+  { href: "#skills", label: "Skills", icon: FaTools },
+  { href: "#projects", label: "Projects", icon: FaFolderOpen },
+  { href: "#contacts", label: "Contacts", icon: FaEnvelope },
+];
+
+export function Navbar() {
+  const { theme, toggleTheme } = useThemeStore();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav className="relative flex items-center justify-between border-b px-4 py-2">
+      <Link href="/" className="flex items-center gap-2">
+        <Image src="/favicon.ico" alt="logo" width={32} height={32} />
+      </Link>
+      <div className="hidden md:flex items-center gap-6">
+        {links.map(({ href, label, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className="flex items-center gap-1 text-sm font-medium hover:underline"
+          >
+            <Icon className="h-4 w-4" />
+            <span>{label}</span>
+          </Link>
+        ))}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleTheme}
+          aria-label="Toggle theme"
+        >
+          {theme === "light" ? (
+            <FaMoon className="h-5 w-5" />
+          ) : (
+            <FaSun className="h-5 w-5" />
+          )}
+        </Button>
+      </div>
+      <div className="md:hidden flex items-center">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setOpen((o) => !o)}
+          aria-label="Toggle menu"
+        >
+          <FaBars className="h-5 w-5" />
+        </Button>
+      </div>
+      {open && (
+        <div className="absolute top-full left-0 w-full border-b bg-background md:hidden">
+          <div className="flex flex-col p-4 gap-2">
+            {links.map(({ href, label, icon: Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex items-center gap-2 py-2"
+                onClick={() => setOpen(false)}
+              >
+                <Icon />
+                <span>{label}</span>
+              </Link>
+            ))}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => {
+                toggleTheme();
+                setOpen(false);
+              }}
+              aria-label="Toggle theme"
+            >
+              {theme === "light" ? (
+                <FaMoon className="h-5 w-5" />
+              ) : (
+                <FaSun className="h-5 w-5" />
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { useThemeStore } from "@/store/theme";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const { theme } = useThemeStore();
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+  }, [theme]);
+
+  return <>{children}</>;
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "ghost";
+  size?: "default" | "icon";
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "default", ...props }, ref) => {
+    const variants: Record<Required<ButtonProps>["variant"], string> = {
+      default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+      ghost: "hover:bg-accent hover:text-accent-foreground",
+    };
+
+    const sizes: Record<Required<ButtonProps>["size"], string> = {
+      default: "h-9 px-4 py-2",
+      icon: "h-9 w-9",
+    };
+
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none",
+          "focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+          variants[variant],
+          sizes[size],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button };

--- a/src/store/theme.ts
+++ b/src/store/theme.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type Theme = "light" | "dark";
+
+interface ThemeStore {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeStore>()(
+  persist(
+    (set) => ({
+      theme: "light",
+      toggleTheme: () => set((state) => ({ theme: state.theme === "light" ? "dark" : "light" })),
+    }),
+    { name: "theme" }
+  )
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,62 +1,66 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-    darkMode: ["class"],
-    content: [
+import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		}
-  	}
+    extend: {
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          1: "hsl(var(--chart-1))",
+          2: "hsl(var(--chart-2))",
+          3: "hsl(var(--chart-3))",
+          4: "hsl(var(--chart-4))",
+          5: "hsl(var(--chart-5))",
+        },
+      },
+    },
   },
-  plugins: [require("tailwindcss-animate")],
-}
+  plugins: [animatePlugin],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add responsive navigation bar with react-icons links and theme toggle
- persist theme choice using zustand and apply via ThemeProvider
- convert Tailwind config to ES module to satisfy lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'tailwindcss'; dependency install forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c51e25a27c8327a3e40b0b5e4e4e45