### PR TITLE
feat: add responsive navbar with theme toggle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import { NavBar } from "@/components/nav-bar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,9 +25,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body>
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>
+          <NavBar />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <ThemeProvider>
           <NavBar />
           {children}

--- a/src/components/nav-bar.module.css
+++ b/src/components/nav-bar.module.css
@@ -1,0 +1,87 @@
+.navBar {
+  width: 100%;
+  border-bottom: 1px solid hsl(var(--border));
+  background-color: hsl(var(--background));
+}
+
+.container {
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.links {
+  display: none;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: inherit;
+}
+
+.toggleGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mobileButton {
+  display: inline-flex;
+}
+
+@media (min-width: 768px) {
+  .links {
+    display: flex;
+  }
+  .mobileButton {
+    display: none;
+  }
+}
+
+.mobileMenu {
+  padding: 0 1rem 1rem;
+}
+
+.mobileLinks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mobileLink {
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.5rem 0;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "./theme-toggle";
 import { FaBars, FaTimes } from "react-icons/fa";
+import styles from "./nav-bar.module.css";
 
 const links = [
   { href: "#about", label: "About" },
@@ -18,48 +19,48 @@ const links = [
 export function NavBar() {
   const [open, setOpen] = useState(false);
 
-  return (
-    <nav className="w-full border-b bg-background/50 backdrop-blur supports-[backdrop-filter]:bg-background/50">
-      <div className="mx-auto flex max-w-5xl items-center justify-between p-4">
-        <Link href="/" className="flex items-center space-x-2">
-          <Image src="/favicon.ico" alt="Logo" width={24} height={24} />
-          <span className="sr-only">Home</span>
-        </Link>
-        <ul className="hidden gap-6 md:flex">
-          {links.map((link) => (
-            <li key={link.href}>
-              <Link href={link.href} className="text-sm font-medium hover:underline">
-                {link.label}
-              </Link>
-            </li>
-          ))}
-        </ul>
-        <div className="flex items-center gap-2">
-          <ThemeToggle />
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden"
-            onClick={() => setOpen(!open)}
-            aria-label="Toggle menu"
-          >
-            {open ? <FaTimes className="h-5 w-5" /> : <FaBars className="h-5 w-5" />}
-          </Button>
-        </div>
-      </div>
-      {open && (
-        <div className="md:hidden px-4 pb-4">
-          <ul className="flex flex-col gap-2">
+    return (
+      <nav className={styles.navBar}>
+        <div className={styles.container}>
+          <Link href="/" className={styles.brand}>
+            <Image src="/favicon.ico" alt="Logo" width={24} height={24} />
+            <span className={styles.srOnly}>Home</span>
+          </Link>
+          <ul className={styles.links}>
             {links.map((link) => (
               <li key={link.href}>
-                <Link href={link.href} className="block py-2 text-sm font-medium">
+                <Link href={link.href} className={styles.link}>
                   {link.label}
                 </Link>
               </li>
             ))}
           </ul>
+          <div className={styles.toggleGroup}>
+            <ThemeToggle />
+            <Button
+              variant="ghost"
+              size="icon"
+              className={styles.mobileButton}
+              onClick={() => setOpen(!open)}
+              aria-label="Toggle menu"
+            >
+              {open ? <FaTimes size={20} /> : <FaBars size={20} />}
+            </Button>
+          </div>
         </div>
-      )}
-    </nav>
-  );
+        {open && (
+          <div className={styles.mobileMenu}>
+            <ul className={styles.mobileLinks}>
+              {links.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className={styles.mobileLink}>
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </nav>
+    );
 }

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "./theme-toggle";
+import { FaBars, FaTimes } from "react-icons/fa";
+
+const links = [
+  { href: "#about", label: "About" },
+  { href: "#features", label: "Features" },
+  { href: "#skills", label: "Skills" },
+  { href: "#projects", label: "Projects" },
+  { href: "#contacts", label: "Contacts" },
+];
+
+export function NavBar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav className="w-full border-b bg-background/50 backdrop-blur supports-[backdrop-filter]:bg-background/50">
+      <div className="mx-auto flex max-w-5xl items-center justify-between p-4">
+        <Link href="/" className="flex items-center space-x-2">
+          <Image src="/favicon.ico" alt="Logo" width={24} height={24} />
+          <span className="sr-only">Home</span>
+        </Link>
+        <ul className="hidden gap-6 md:flex">
+          {links.map((link) => (
+            <li key={link.href}>
+              <Link href={link.href} className="text-sm font-medium hover:underline">
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={() => setOpen(!open)}
+            aria-label="Toggle menu"
+          >
+            {open ? <FaTimes className="h-5 w-5" /> : <FaBars className="h-5 w-5" />}
+          </Button>
+        </div>
+      </div>
+      {open && (
+        <div className="md:hidden px-4 pb-4">
+          <ul className="flex flex-col gap-2">
+            {links.map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className="block py-2 text-sm font-medium">
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useThemeStore } from "@/lib/theme-store";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const theme = useThemeStore((state) => state.theme);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
+  return <>{children}</>;
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -8,8 +8,8 @@ export function ThemeToggle() {
   const { theme, toggleTheme } = useThemeStore();
 
   return (
-    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
-      {theme === "dark" ? <FaSun className="h-5 w-5" /> : <FaMoon className="h-5 w-5" />}
-    </Button>
-  );
+      <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+        {theme === "dark" ? <FaSun size={20} /> : <FaMoon size={20} />}
+      </Button>
+    );
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useThemeStore } from "@/lib/theme-store";
+import { Button } from "@/components/ui/button";
+import { FaMoon, FaSun } from "react-icons/fa";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useThemeStore();
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+      {theme === "dark" ? <FaSun className="h-5 w-5" /> : <FaMoon className="h-5 w-5" />}
+    </Button>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors " +
+    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/lib/theme-store.ts
+++ b/src/lib/theme-store.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type Theme = "light" | "dark";
+
+interface ThemeState {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      theme: "light",
+      toggleTheme: () => {
+        const next = get().theme === "light" ? "dark" : "light";
+        set({ theme: next });
+      },
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: "theme-storage",
+    }
+  )
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,62 +1,66 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-    darkMode: ["class"],
-    content: [
+import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		}
-  	}
+    extend: {
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          "1": "hsl(var(--chart-1))",
+          "2": "hsl(var(--chart-2))",
+          "3": "hsl(var(--chart-3))",
+          "4": "hsl(var(--chart-4))",
+          "5": "hsl(var(--chart-5))",
+        },
+      },
+    },
   },
-  plugins: [require("tailwindcss-animate")],
-}
+  plugins: [animate],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add responsive navbar with links and favicon
- implement dark/light theme toggle with Zustand persistence
- convert Tailwind config to ESM and include theme provider

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Module not found errors)

------
https://chatgpt.com/codex/tasks/task_e_68c51e25a27c8327a3e40b0b5e4e4e45