### PR TITLE
Center mobile logo between menu and theme toggle

### DIFF
--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -72,7 +72,7 @@ export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark
                     </div>
                 </Link>
 
-                <nav className="hidden md:flex items-center gap-4">
+                <nav className="hidden md:flex items-center gap-4 md:mx-auto">
                     {links.map((l) => (
                         <Button key={l.href} variant="ghost" asChild>
                             <Link href={l.href}>{l.label}</Link>

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -37,33 +37,7 @@ export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark
 
     return (
         <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
-            <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
-                  <Link href="/" className="flex items-center gap-2 font-semibold">
-                      <div className="relative h-6 w-6">
-                          <Image
-                              src={currentTheme === "dark" ? "/logo-light.svg" : "/logo-dark.svg"}
-                              alt="Logo"
-                              fill
-                              sizes="24px"
-                              className="object-contain"
-                          />
-                      </div>
-                  </Link>
-
-                <nav className="hidden md:flex items-center gap-4">
-                    {links.map((l) => (
-                        <Button key={l.href} variant="ghost" asChild>
-                            <Link href={l.href}>{l.label}</Link>
-                        </Button>
-                    ))}
-                </nav>
-
-                <div className="flex items-center gap-2">
-                    <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
-                        {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
-                    </Button>
-                </div>
-
+            <div className="relative mx-auto flex h-14 max-w-6xl items-center px-4">
                 <div className="md:hidden">
                     <Sheet>
                         <SheetTrigger asChild>
@@ -81,6 +55,35 @@ export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark
                             </nav>
                         </SheetContent>
                     </Sheet>
+                </div>
+
+                <Link
+                    href="/"
+                    className="absolute left-1/2 -translate-x-1/2 md:static md:translate-x-0 flex items-center gap-2 font-semibold"
+                >
+                    <div className="relative h-6 w-6">
+                        <Image
+                            src={currentTheme === "dark" ? "/logo-light.svg" : "/logo-dark.svg"}
+                            alt="Logo"
+                            fill
+                            sizes="24px"
+                            className="object-contain"
+                        />
+                    </div>
+                </Link>
+
+                <nav className="hidden md:flex items-center gap-4">
+                    {links.map((l) => (
+                        <Button key={l.href} variant="ghost" asChild>
+                            <Link href={l.href}>{l.label}</Link>
+                        </Button>
+                    ))}
+                </nav>
+
+                <div className="ml-auto flex items-center gap-2">
+                    <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
+                        {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
+                    </Button>
                 </div>
             </div>
             <Separator />


### PR DESCRIPTION
## Summary
- center logo on small screens between menu trigger and theme toggle
- keep menu trigger left and dark/light toggle right

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c58618410c8327aa7177905d6f6dbd