### PR TITLE
fix hydration warning and sheet accessibility

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,17 +32,24 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: ReactNode
 }>) {
-  const cookieStore = await cookies()
+  const cookieStore = cookies()
   const initialTheme = cookieStore.get("theme")?.value === "dark" ? "dark" : "light"
 
   return (
-    <html lang="en" className={initialTheme === "dark" ? "dark" : ""}>
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html
+      lang="en"
+      className={initialTheme === "dark" ? "dark" : ""}
+      suppressHydrationWarning
+    >
+      <body
+        className={`${geistSans.variable} ${geistMono.variable}`}
+        suppressHydrationWarning
+      >
         <Navbar initialTheme={initialTheme} />
         <main>{children}</main>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,12 +32,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: ReactNode
 }>) {
-  const cookieStore = cookies()
+  const cookieStore = await cookies()
   const initialTheme = cookieStore.get("theme")?.value === "dark" ? "dark" : "light"
 
   return (

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -6,7 +6,8 @@ import {
     Sheet,
     SheetTrigger,
     SheetContent,
-    SheetTitle
+    SheetTitle,
+    SheetDescription,
 } from "@/components/ui/sheet"
 import { Menu } from "lucide-react"
 import { FaMoon, FaSun } from "react-icons/fa"
@@ -53,6 +54,9 @@ export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark
                         </SheetTrigger>
                         <SheetContent side="left">
                             <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
+                            <SheetDescription className="sr-only">
+                                Site navigation links
+                            </SheetDescription>
                             <nav className="grid gap-4 py-4">
                                 {links.map((l) => (
                                     <Button key={l.href} variant="ghost" asChild>

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button"
 import {
     Sheet,
     SheetTrigger,
-    SheetContent
+    SheetContent,
+    SheetTitle
 } from "@/components/ui/sheet"
 import { Menu } from "lucide-react"
 import { FaMoon, FaSun } from "react-icons/fa"
@@ -51,6 +52,7 @@ export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark
                             </Button>
                         </SheetTrigger>
                         <SheetContent side="left">
+                            <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
                             <nav className="grid gap-4 py-4">
                                 {links.map((l) => (
                                     <Button key={l.href} variant="ghost" asChild>


### PR DESCRIPTION
## Summary
- avoid React hydration warning by synchronously reading theme cookie and suppressing class mismatches
- include a hidden title in the mobile navigation sheet for accessible dialog semantics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c662a5450c8327b0fb041959c528a5