### PR TITLE
Default theme to system when no local record

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css"
 import Navbar from "@/components/ui/navbar"
 import { cookies } from "next/headers"
 import type { ReactNode } from "react"
+import ThemeScript from "@/components/theme-script"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -46,6 +47,9 @@ export default async function RootLayout({
       className={initialTheme === "dark" ? "dark" : ""}
       suppressHydrationWarning
     >
+      <head>
+        <ThemeScript />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable}`}
         suppressHydrationWarning

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -1,0 +1,15 @@
+export default function ThemeScript() {
+  const code = `(() => {
+    try {
+      const stored = localStorage.getItem('theme')
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      const theme = stored ?? (systemDark ? 'dark' : 'light')
+      document.documentElement.classList.toggle('dark', theme === 'dark')
+      localStorage.setItem('theme', theme)
+      document.cookie = 'theme=' + theme + ';path=/;max-age=' + (60 * 60 * 24 * 365)
+    } catch {}
+  })();`
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: injected client script
+  return <script dangerouslySetInnerHTML={{ __html: code }} />
+}
+

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -26,14 +26,12 @@ const links = [
 
 export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark" }) {
     const theme = useThemeStore((state) => state.theme)
-    const setTheme = useThemeStore((state) => state.setTheme)
     const toggleTheme = useThemeStore((state) => state.toggleTheme)
     const [mounted, setMounted] = useState(false)
 
     useEffect(() => {
-        setTheme(initialTheme)
         setMounted(true)
-    }, [initialTheme, setTheme])
+    }, [])
 
     const currentTheme = mounted ? theme : initialTheme
 

--- a/src/lib/theme-store.ts
+++ b/src/lib/theme-store.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 export type Theme = 'light' | 'dark'
 
@@ -10,19 +11,37 @@ interface ThemeState {
   toggleTheme: () => void
 }
 
-export const useThemeStore = create<ThemeState>((set, get) => ({
-  theme: 'light',
-  setTheme: (theme) => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
-    set({ theme })
-    window.localStorage.setItem('theme', theme)
-    document.cookie = `theme=${theme};path=/;max-age=${60 * 60 * 24 * 365}`
-  },
-  toggleTheme: () => {
-    const next = get().theme === 'light' ? 'dark' : 'light'
-    document.documentElement.classList.toggle('dark', next === 'dark')
-    set({ theme: next })
-    window.localStorage.setItem('theme', next)
-    document.cookie = `theme=${next};path=/;max-age=${60 * 60 * 24 * 365}`
-  },
-}))
+const getSystemTheme = (): Theme =>
+  window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+
+const getInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') return 'light'
+  const stored = window.localStorage.getItem('theme') as Theme | null
+  return stored ?? getSystemTheme()
+}
+
+const initialTheme = getInitialTheme()
+if (typeof window !== 'undefined') {
+  document.documentElement.classList.toggle('dark', initialTheme === 'dark')
+  document.cookie = `theme=${initialTheme};path=/;max-age=${60 * 60 * 24 * 365}`
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      theme: initialTheme,
+      setTheme: (theme) => {
+        document.documentElement.classList.toggle('dark', theme === 'dark')
+        set({ theme })
+        document.cookie = `theme=${theme};path=/;max-age=${60 * 60 * 24 * 365}`
+      },
+      toggleTheme: () => {
+        const next = get().theme === 'light' ? 'dark' : 'light'
+        document.documentElement.classList.toggle('dark', next === 'dark')
+        set({ theme: next })
+        document.cookie = `theme=${next};path=/;max-age=${60 * 60 * 24 * 365}`
+      },
+    }),
+    { name: 'theme' }
+  )
+)


### PR DESCRIPTION
## Summary
- Default theme to the user's system preference when no stored theme exists
- Persist theme with zustand middleware and sync DOM/cookies
- Simplify navbar theme initialization

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c670fdd06483278984800951d109fa