### PR TITLE
Align default theme with system preference

### DIFF
--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -24,18 +24,16 @@ const links = [
     { href: "#contacts", label: "Contacts" },
 ]
 
-export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark" }) {
-    const theme = useThemeStore((state) => state.theme)
-    const setTheme = useThemeStore((state) => state.setTheme)
-    const toggleTheme = useThemeStore((state) => state.toggleTheme)
-    const [mounted, setMounted] = useState(false)
+ export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark" }) {
+     const theme = useThemeStore((state) => state.theme)
+     const toggleTheme = useThemeStore((state) => state.toggleTheme)
+     const [mounted, setMounted] = useState(false)
 
-    useEffect(() => {
-        setTheme(initialTheme)
-        setMounted(true)
-    }, [initialTheme, setTheme])
+     useEffect(() => {
+         setMounted(true)
+     }, [])
 
-    const currentTheme = mounted ? theme : initialTheme
+     const currentTheme = mounted ? theme : initialTheme
 
     return (
         <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">

--- a/src/lib/theme-store.ts
+++ b/src/lib/theme-store.ts
@@ -1,8 +1,9 @@
-'use client'
+"use client"
 
-import { create } from 'zustand'
+import { create } from "zustand"
+import { persist, createJSONStorage } from "zustand/middleware"
 
-export type Theme = 'light' | 'dark'
+export type Theme = "light" | "dark"
 
 interface ThemeState {
   theme: Theme
@@ -10,19 +11,38 @@ interface ThemeState {
   toggleTheme: () => void
 }
 
-export const useThemeStore = create<ThemeState>((set, get) => ({
-  theme: 'light',
-  setTheme: (theme) => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
-    set({ theme })
-    window.localStorage.setItem('theme', theme)
-    document.cookie = `theme=${theme};path=/;max-age=${60 * 60 * 24 * 365}`
-  },
-  toggleTheme: () => {
-    const next = get().theme === 'light' ? 'dark' : 'light'
-    document.documentElement.classList.toggle('dark', next === 'dark')
-    set({ theme: next })
-    window.localStorage.setItem('theme', next)
-    document.cookie = `theme=${next};path=/;max-age=${60 * 60 * 24 * 365}`
-  },
-}))
+const getSystemTheme = (): Theme =>
+  window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+
+// Apply system theme immediately if no stored preference
+const systemTheme = getSystemTheme()
+document.documentElement.classList.toggle("dark", systemTheme === "dark")
+document.cookie = `theme=${systemTheme};path=/;max-age=${60 * 60 * 24 * 365}`
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      theme: systemTheme,
+      setTheme: (theme) => {
+        document.documentElement.classList.toggle("dark", theme === "dark")
+        set({ theme })
+        document.cookie = `theme=${theme};path=/;max-age=${60 * 60 * 24 * 365}`
+      },
+      toggleTheme: () => {
+        const next = get().theme === "light" ? "dark" : "light"
+        document.documentElement.classList.toggle("dark", next === "dark")
+        set({ theme: next })
+        document.cookie = `theme=${next};path=/;max-age=${60 * 60 * 24 * 365}`
+      },
+    }),
+    {
+      name: "theme",
+      storage: createJSONStorage(() => localStorage),
+      onRehydrateStorage: () => (state) => {
+        const theme = state?.theme ?? systemTheme
+        document.documentElement.classList.toggle("dark", theme === "dark")
+        document.cookie = `theme=${theme};path=/;max-age=${60 * 60 * 24 * 365}`
+      },
+    }
+  )
+)


### PR DESCRIPTION
## Summary
- Persist theme preference using Zustand, defaulting to system settings when no record exists
- Simplify Navbar theme handling to rely on the store's state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c670fdd06483278984800951d109fa