### PR TITLE
feat: default to system theme when no preference stored

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css"
 import Navbar from "@/components/ui/navbar"
 import { cookies } from "next/headers"
 import type { ReactNode } from "react"
+import Script from "next/script"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,19 +39,35 @@ export default async function RootLayout({
   children: ReactNode
 }>) {
   const cookieStore = await cookies()
-  const initialTheme = cookieStore.get("theme")?.value === "dark" ? "dark" : "light"
+  const cookieTheme = cookieStore.get("theme")?.value as 'light' | 'dark' | undefined
 
   return (
     <html
       lang="en"
-      className={initialTheme === "dark" ? "dark" : ""}
+      className={cookieTheme === "dark" ? "dark" : ""}
       suppressHydrationWarning
     >
+      <head>
+        <Script id="theme-script" strategy="beforeInteractive">
+          {`
+            (function() {
+              const cookie = document.cookie.match(/(?:^|; )theme=([^;]+)/)?.[1];
+              const stored = localStorage.getItem('theme') || cookie;
+              if (stored) {
+                document.documentElement.classList.toggle('dark', stored === 'dark');
+              } else {
+                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                document.documentElement.classList.toggle('dark', prefersDark);
+              }
+            })();
+          `}
+        </Script>
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable}`}
         suppressHydrationWarning
       >
-        <Navbar initialTheme={initialTheme} />
+        <Navbar initialTheme={cookieTheme} />
         <main>{children}</main>
       </body>
     </html>

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -73,11 +73,18 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                 <Link href="/" className="flex items-center gap-2 font-semibold">
                     <div className="relative h-6 w-6">
                         <Image
-                            src={currentTheme === "dark" ? "/logo-light.svg" : "/logo-dark.svg"}
+                            src="/logo-dark.svg"
                             alt="Logo"
                             fill
                             sizes="24px"
-                            className="object-contain"
+                            className="object-contain dark:hidden"
+                        />
+                        <Image
+                            src="/logo-light.svg"
+                            alt="Logo"
+                            fill
+                            sizes="24px"
+                            className="hidden object-contain dark:block"
                         />
                     </div>
                 </Link>

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -24,18 +24,20 @@ const links = [
     { href: "#contacts", label: "Contacts" },
 ]
 
-export default function Navbar({ initialTheme }: { initialTheme: "light" | "dark" }) {
+export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dark" }) {
     const theme = useThemeStore((state) => state.theme)
     const setTheme = useThemeStore((state) => state.setTheme)
     const toggleTheme = useThemeStore((state) => state.toggleTheme)
     const [mounted, setMounted] = useState(false)
 
     useEffect(() => {
-        setTheme(initialTheme)
+        if (initialTheme) {
+            setTheme(initialTheme)
+        }
         setMounted(true)
     }, [initialTheme, setTheme])
 
-    const currentTheme = mounted ? theme : initialTheme
+    const currentTheme = mounted ? theme : initialTheme || theme
 
     return (
         <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">

--- a/src/lib/theme-store.ts
+++ b/src/lib/theme-store.ts
@@ -10,8 +10,22 @@ interface ThemeState {
   toggleTheme: () => void
 }
 
+const getInitialTheme = (): Theme => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('theme') as Theme | null
+    if (stored) {
+      document.documentElement.classList.toggle('dark', stored === 'dark')
+      return stored
+    }
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    document.documentElement.classList.toggle('dark', prefersDark)
+    return prefersDark ? 'dark' : 'light'
+  }
+  return 'light'
+}
+
 export const useThemeStore = create<ThemeState>((set, get) => ({
-  theme: 'light',
+  theme: getInitialTheme(),
   setTheme: (theme) => {
     document.documentElement.classList.toggle('dark', theme === 'dark')
     set({ theme })


### PR DESCRIPTION
## Summary
- derive initial theme from localStorage or system preference
- inject early script to sync theme before hydration
- adjust navbar to handle optional initial theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c6800a3dcc8327aea0326a6c5487a0