### PR TITLE
Remove remote font dependency for offline build

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,10 @@
 import type { Metadata } from "next"
-import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 import Navbar from "@/components/ui/navbar"
 import { cookies } from "next/headers"
 import type { ReactNode } from "react"
 import Script from "next/script"
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Antholem",
@@ -63,10 +53,7 @@ export default async function RootLayout({
           `}
         </Script>
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable}`}
-        suppressHydrationWarning
-      >
+      <body className="font-sans" suppressHydrationWarning>
         <Navbar initialTheme={cookieTheme} />
         <main>{children}</main>
       </body>

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -13,7 +13,7 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-family: var(--font-geist-sans);
+  font-family: system-ui, sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -34,8 +34,8 @@
   grid-row-start: 2;
 }
 
-.main ol {
-  font-family: var(--font-geist-mono);
+  .main ol {
+    font-family: ui-monospace, monospace;
   padding-left: 0;
   margin: 0;
   font-size: 14px;


### PR DESCRIPTION
## Summary
- avoid build failures by removing Google Fonts usage
- use system fonts in layout and page styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c692e9fcc883278a71c1357db172b9