### PR TITLE
Add Gmail-backed contact form sender

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+
+import { sendContactEmail } from '@/lib/email';
+
+interface ContactRequestBody {
+  name?: unknown;
+  email?: unknown;
+  message?: unknown;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateRequest(body: ContactRequestBody) {
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const email = typeof body.email === 'string' ? body.email.trim() : '';
+  const message = typeof body.message === 'string' ? body.message.trim() : '';
+
+  if (!name) {
+    return { error: 'Please provide your name.' } as const;
+  }
+
+  if (!email || !EMAIL_REGEX.test(email)) {
+    return { error: 'Please provide a valid email address.' } as const;
+  }
+
+  if (!message) {
+    return { error: 'Please include a message.' } as const;
+  }
+
+  if (message.length > 5000) {
+    return { error: 'Message is too long. Please keep it under 5000 characters.' } as const;
+  }
+
+  return { name, email, message } as const;
+}
+
+export async function POST(request: Request) {
+  let parsedBody: ContactRequestBody;
+
+  try {
+    parsedBody = (await request.json()) as ContactRequestBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request payload.' }, { status: 400 });
+  }
+
+  const validation = validateRequest(parsedBody);
+
+  if ('error' in validation) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  try {
+    await sendContactEmail(validation);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'EmailConfigurationError') {
+      return NextResponse.json({ error: 'Email service is not configured.' }, { status: 500 });
+    }
+
+    console.error('Failed to send contact email:', error);
+    return NextResponse.json({ error: 'Unable to send your message at this time.' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,9 @@
+import ContactForm from "@/components/contact-form";
+
 export default function Home() {
-  return <div>Home</div>;
+  return (
+    <main>
+      <ContactForm />
+    </main>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,17 @@
+import ContactForm from '@/components/contact-form';
+
 export default function Home() {
   return (
-    <div>
-      Home
-    </div>
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-12 px-4 py-16">
+      <section className="space-y-4 text-center">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+          Let&apos;s build something great together
+        </h1>
+        <p className="text-base text-muted-foreground sm:text-lg">
+          Have a project in mind or just want to say hi? Drop a message below and it will be sent straight to my inbox.
+        </p>
+      </section>
+      <ContactForm />
+    </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,3 @@
-import ContactForm from '@/components/contact-form';
-
 export default function Home() {
-  return (
-    <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-12 px-4 py-16">
-      <section className="space-y-4 text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-          Let&apos;s build something great together
-        </h1>
-        <p className="text-base text-muted-foreground sm:text-lg">
-          Have a project in mind or just want to say hi? Drop a message below and it will be sent straight to my inbox.
-        </p>
-      </section>
-      <ContactForm />
-    </main>
-  );
+  return <div>Home</div>;
 }

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { type ChangeEvent, FormEvent, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  name: string;
+  email: string;
+  message: string;
+}
+
+type FormStatus =
+  | { state: 'idle'; message: string | null }
+  | { state: 'submitting'; message: string | null }
+  | { state: 'success'; message: string }
+  | { state: 'error'; message: string };
+
+const initialValues: FormValues = {
+  name: '',
+  email: '',
+  message: '',
+};
+
+const initialStatus: FormStatus = { state: 'idle', message: null };
+
+export default function ContactForm() {
+  const [values, setValues] = useState<FormValues>(initialValues);
+  const [status, setStatus] = useState<FormStatus>(initialStatus);
+
+  const handleChange = (field: keyof FormValues) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setValues((previous) => ({ ...previous, [field]: event.target.value }));
+    };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus({ state: 'submitting', message: 'Sending your message…' });
+
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+
+      const payload = (await response.json()) as { error?: string } | { success?: boolean };
+
+      if (!response.ok) {
+        throw new Error('error' in payload && payload.error ? payload.error : 'Failed to send message.');
+      }
+
+      setValues(initialValues);
+      setStatus({ state: 'success', message: 'Thanks! Your message has been delivered.' });
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Something went wrong while sending your message.';
+      setStatus({ state: 'error', message });
+    }
+  };
+
+  const isSubmitting = status.state === 'submitting';
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-xl flex-col gap-4 rounded-lg border border-border bg-background p-6 shadow-sm">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="name" className="text-sm font-medium text-foreground">
+          Your name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          value={values.name}
+          onChange={handleChange('name')}
+          className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          placeholder="Juan Dela Cruz"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="email" className="text-sm font-medium text-foreground">
+          Your email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          value={values.email}
+          onChange={handleChange('email')}
+          className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          placeholder="you@example.com"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="message" className="text-sm font-medium text-foreground">
+          How can I help?
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          required
+          rows={5}
+          value={values.message}
+          onChange={handleChange('message')}
+          className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          placeholder="Tell me about your project or question."
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Button type="submit" disabled={isSubmitting} className="w-full justify-center">
+          {isSubmitting ? 'Sending…' : 'Send message'}
+        </Button>
+        {status.message && (
+          <p
+            className={`text-sm ${
+              status.state === 'error'
+                ? 'text-destructive'
+                : status.state === 'success'
+                  ? 'text-emerald-600'
+                  : 'text-muted-foreground'
+            }`}
+          >
+            {status.message}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -82,7 +82,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
     .label{display:block;font-size:12px;color:#64748b;margin-bottom:4px;text-transform:uppercase;letter-spacing:.02em;}
     .value{font-size:15px;color:#0f172a;margin:0 0 16px;}
     .msg{padding:14px;border:1px solid #e5e7eb;border-radius:8px;background:#fafafa;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
-    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#000000;color:#ffffff;font-weight:600;}
+    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#2563eb;color:#ffffff;font-weight:600;}
     .footer{padding:16px 24px;color:#64748b;font-size:12px;border-top:1px solid #e5e7eb;background:#fafafa;}
     @media (prefers-color-scheme: dark){
       body{background:#0b0c10;color:#e5e7eb;}
@@ -91,7 +91,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
       .body{color:#e5e7eb;}
       .value{color:#e5e7eb;}
       .msg{background:#0f172a;border-color:#1f2937;color:#e5e7eb;}
-      .btn{background:#ffffff;color:#000000;}
+      .btn{color:#ffffff;}
       .footer{background:#0f172a;border-top-color:#1f2937;color:#9ca3af;}
     }
   </style>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,244 @@
+import { connect } from 'tls';
+
+interface ContactMessage {
+  name: string;
+  email: string;
+  message: string;
+}
+
+class EmailConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmailConfigurationError';
+  }
+}
+
+const SMTP_PORT = 465;
+const SMTP_HOST = 'smtp.gmail.com';
+
+function sanitizeHeaderValue(value: string, fallback = ''): string {
+  const cleaned = value.replace(/[\r\n]+/g, ' ').trim();
+  return cleaned || fallback;
+}
+
+function sanitizeEmail(value: string): string {
+  return value.replace(/[\r\n\s]+/g, '').trim();
+}
+
+function normalizeMessageBody(body: string): string {
+  const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const dotStuffed = normalized.replace(/\n\./g, '\n..');
+  return dotStuffed.split('\n').join('\r\n');
+}
+
+function toBase64(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function createLineReader(socket: import('tls').TLSSocket) {
+  let buffer = '';
+  const pending: { resolve: (line: string) => void; reject: (error: Error) => void }[] = [];
+  const queued: string[] = [];
+
+  const failPending = (error: Error) => {
+    while (pending.length > 0) {
+      const { reject } = pending.shift()!;
+      reject(error);
+    }
+  };
+
+  socket.setEncoding('utf8');
+
+  socket.on('data', (chunk) => {
+    buffer += chunk;
+    let index;
+    while ((index = buffer.indexOf('\r\n')) !== -1) {
+      const line = buffer.slice(0, index);
+      buffer = buffer.slice(index + 2);
+      if (pending.length > 0) {
+        pending.shift()!.resolve(line);
+      } else {
+        queued.push(line);
+      }
+    }
+  });
+
+  socket.on('error', (error) => {
+    failPending(error instanceof Error ? error : new Error(String(error)));
+  });
+
+  socket.on('end', () => {
+    failPending(new Error('SMTP connection ended unexpectedly.'));
+  });
+
+  socket.on('close', () => {
+    failPending(new Error('SMTP connection closed unexpectedly.'));
+  });
+
+  socket.on('timeout', () => {
+    const timeoutError = new Error('SMTP connection timed out.');
+    failPending(timeoutError);
+    socket.destroy(timeoutError);
+  });
+
+  return () =>
+    new Promise<string>((resolve, reject) => {
+      if (queued.length > 0) {
+        resolve(queued.shift()!);
+        return;
+      }
+      pending.push({ resolve, reject });
+    });
+}
+
+async function write(socket: import('tls').TLSSocket, data: string) {
+  await new Promise<void>((resolve, reject) => {
+    if (!socket.writable) {
+      reject(new Error('SMTP connection is not writable.'));
+      return;
+    }
+
+    const cleanup = () => {
+      socket.off('error', onError);
+      socket.off('drain', onDrain);
+    };
+
+    const onError = (error: unknown) => {
+      cleanup();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+
+    socket.on('error', onError);
+    const flushed = socket.write(data, 'utf8');
+    if (flushed) {
+      process.nextTick(onDrain);
+    } else {
+      socket.once('drain', onDrain);
+    }
+  });
+}
+
+async function writeLine(socket: import('tls').TLSSocket, line: string) {
+  await write(socket, `${line}\r\n`);
+}
+
+async function readResponse(
+  readLine: () => Promise<string>,
+  expectedCode: string,
+  commandLabel: string,
+) {
+  const lines: string[] = [];
+  while (true) {
+    const line = await readLine();
+    lines.push(line);
+    if (line.length < 4) {
+      continue;
+    }
+    const code = line.slice(0, 3);
+    const delimiter = line.charAt(3);
+    if (delimiter === ' ') {
+      if (code !== expectedCode) {
+        throw new Error(
+          `Unexpected SMTP response while executing ${commandLabel}: ${lines.join('\n')}`,
+        );
+      }
+      return lines.join('\n');
+    }
+  }
+}
+
+async function sendCommand(
+  socket: import('tls').TLSSocket,
+  readLine: () => Promise<string>,
+  command: string,
+  expectedCode: string,
+  label: string,
+) {
+  await writeLine(socket, command);
+  return readResponse(readLine, expectedCode, label);
+}
+
+export async function sendContactEmail({ name, email, message }: ContactMessage): Promise<void> {
+  const fromEmail = process.env.APP_FROM_EMAIL;
+  const fromPassword = process.env.APP_FROM_PASSWORD;
+  const toEmail = process.env.APP_TO_EMAIL;
+
+  if (!fromEmail || !fromPassword || !toEmail) {
+    throw new EmailConfigurationError('Email environment variables are not fully configured.');
+  }
+
+  const sanitizedName = sanitizeHeaderValue(name, 'Portfolio Visitor');
+  const replyTo = sanitizeEmail(email);
+  const subject = `New portfolio message from ${sanitizedName}`;
+  const composedBody = `You received a new message through your portfolio contact form.\n\nName: ${sanitizedName}\nEmail: ${
+    replyTo || 'not provided'
+  }\n\nMessage:\n${message.trim()}`;
+  const messageBody = normalizeMessageBody(composedBody);
+
+  const socket = connect({
+    host: SMTP_HOST,
+    port: SMTP_PORT,
+    servername: SMTP_HOST,
+  });
+
+  socket.setTimeout(15000);
+
+  const connectPromise = new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      socket.off('secureConnect', onConnect);
+      socket.off('error', onError);
+    };
+
+    const onConnect = () => {
+      cleanup();
+      resolve();
+    };
+
+    const onError = (error: unknown) => {
+      cleanup();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    socket.once('secureConnect', onConnect);
+    socket.once('error', onError);
+  });
+
+  await connectPromise;
+
+  const readLine = createLineReader(socket);
+
+  try {
+    await readResponse(readLine, '220', 'initial greeting');
+    await sendCommand(socket, readLine, 'EHLO portfolio.local', '250', 'EHLO');
+    await sendCommand(socket, readLine, 'AUTH LOGIN', '334', 'AUTH LOGIN');
+    await sendCommand(socket, readLine, toBase64(fromEmail), '334', 'username authentication');
+    await sendCommand(socket, readLine, toBase64(fromPassword), '235', 'password authentication');
+    await sendCommand(socket, readLine, `MAIL FROM:<${fromEmail}>`, '250', 'MAIL FROM');
+    await sendCommand(socket, readLine, `RCPT TO:<${toEmail}>`, '250', 'RCPT TO');
+    await sendCommand(socket, readLine, 'DATA', '354', 'DATA');
+
+    const headers = [
+      `From: "${sanitizedName}" <${fromEmail}>`,
+      `To: ${toEmail}`,
+      `Reply-To: ${replyTo || fromEmail}`,
+      `Subject: ${sanitizeHeaderValue(subject)}`,
+      `Date: ${new Date().toUTCString()}`,
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset=utf-8',
+      'Content-Transfer-Encoding: 8bit',
+      '',
+      messageBody,
+    ].join('\r\n');
+
+    await write(socket, `${headers}\r\n.\r\n`);
+    await readResponse(readLine, '250', 'message delivery');
+    await sendCommand(socket, readLine, 'QUIT', '221', 'QUIT');
+  } finally {
+    socket.end();
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -82,7 +82,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
     .label{display:block;font-size:12px;color:#64748b;margin-bottom:4px;text-transform:uppercase;letter-spacing:.02em;}
     .value{font-size:15px;color:#0f172a;margin:0 0 16px;}
     .msg{padding:14px;border:1px solid #e5e7eb;border-radius:8px;background:#fafafa;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
-    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#2563eb;color:#ffffff;font-weight:600;}
+    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:600;border:1px solid #0f172a;color:#0f172a;background:transparent;}
     .footer{padding:16px 24px;color:#64748b;font-size:12px;border-top:1px solid #e5e7eb;background:#fafafa;}
     @media (prefers-color-scheme: dark){
       body{background:#0b0c10;color:#e5e7eb;}
@@ -91,7 +91,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
       .body{color:#e5e7eb;}
       .value{color:#e5e7eb;}
       .msg{background:#0f172a;border-color:#1f2937;color:#e5e7eb;}
-      .btn{color:#ffffff;}
+      .btn{color:#e5e7eb;border-color:#e5e7eb;background:transparent;}
       .footer{background:#0f172a;border-top-color:#1f2937;color:#9ca3af;}
     }
   </style>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,4 @@
-import { connect } from 'tls';
+import { connect } from "tls";
 
 interface ContactMessage {
   name: string;
@@ -9,35 +9,126 @@ interface ContactMessage {
 class EmailConfigurationError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'EmailConfigurationError';
+    this.name = "EmailConfigurationError";
   }
 }
 
 const SMTP_PORT = 465;
-const SMTP_HOST = 'smtp.gmail.com';
+const SMTP_HOST = "smtp.gmail.com";
 
-function sanitizeHeaderValue(value: string, fallback = ''): string {
-  const cleaned = value.replace(/[\r\n]+/g, ' ').trim();
+function sanitizeHeaderValue(value: string, fallback = ""): string {
+  const cleaned = value.replace(/[\r\n]+/g, " ").trim();
   return cleaned || fallback;
 }
 
 function sanitizeEmail(value: string): string {
-  return value.replace(/[\r\n\s]+/g, '').trim();
+  return value.replace(/[\r\n\s]+/g, "").trim();
 }
 
 function normalizeMessageBody(body: string): string {
-  const normalized = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-  const dotStuffed = normalized.replace(/\n\./g, '\n..');
-  return dotStuffed.split('\n').join('\r\n');
+  const normalized = body.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const dotStuffed = normalized.replace(/\n\./g, "\n..");
+  return dotStuffed.split("\n").join("\r\n");
 }
 
 function toBase64(value: string): string {
-  return Buffer.from(value, 'utf8').toString('base64');
+  return Buffer.from(value, "utf8").toString("base64");
 }
 
-function createLineReader(socket: import('tls').TLSSocket) {
-  let buffer = '';
-  const pending: { resolve: (line: string) => void; reject: (error: Error) => void }[] = [];
+function escapeHtml(s: string) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildPlainText(name: string, replyTo: string, msg: string) {
+  return [
+    "You received a new message through your portfolio.",
+    "",
+    `Name: ${name}`,
+    `Email: ${replyTo || "not provided"}`,
+    "",
+    "Message:",
+    msg.trim(),
+    "",
+    "—",
+    "This email came from your portfolio.",
+  ].join("\n");
+}
+
+function buildHtml(name: string, replyTo: string, msg: string) {
+  const preheader = "New message from your portfolio. Open to view.";
+  const safeMsg = escapeHtml(msg.trim()).replace(/\r?\n/g, "<br>");
+  const replyHref = replyTo ? `mailto:${replyTo}` : "#";
+
+  return normalizeMessageBody(`\
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="color-scheme" content="light dark">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>New message</title>
+  <style>
+    .preheader{display:none!important;visibility:hidden;opacity:0;color:transparent;height:0;width:0;overflow:hidden;mso-hide:all;}
+    body{margin:0;padding:0;background:#f5f7fb;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#0f172a;}
+    .wrapper{width:100%;padding:24px 0;}
+    .container{max-width:600px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;}
+    .header{padding:20px 24px;border-bottom:1px solid #e5e7eb;}
+    .title{font-size:18px;line-height:1.4;margin:0;}
+    .body{padding:20px 24px;font-size:15px;line-height:1.6;}
+    .label{display:block;font-size:12px;color:#64748b;margin-bottom:4px;text-transform:uppercase;letter-spacing:.02em;}
+    .value{font-size:15px;color:#0f172a;margin:0 0 16px;}
+    .msg{padding:14px;border:1px solid #e5e7eb;border-radius:8px;background:#fafafa;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
+    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#2563eb;color:#ffffff;font-weight:600;}
+    .footer{padding:16px 24px;color:#64748b;font-size:12px;border-top:1px solid #e5e7eb;background:#fafafa;}
+    @media (prefers-color-scheme: dark){
+      body{background:#0b0c10;color:#e5e7eb;}
+      .container{background:#111827;border-color:#1f2937;}
+      .header{border-bottom-color:#1f2937;}
+      .body{color:#e5e7eb;}
+      .value{color:#e5e7eb;}
+      .msg{background:#0f172a;border-color:#1f2937;color:#e5e7eb;}
+      .footer{background:#0f172a;border-top-color:#1f2937;color:#9ca3af;}
+    }
+  </style>
+</head>
+<body>
+  <span class="preheader">${preheader}</span>
+  <div class="wrapper">
+    <div class="container">
+      <div class="header">
+        <h1 class="title">New message</h1>
+      </div>
+      <div class="body">
+        <span class="label">Name</span>
+        <p class="value">${escapeHtml(name)}</p>
+
+        <span class="label">Email</span>
+        <p class="value">${replyTo ? escapeHtml(replyTo) : "not provided"}</p>
+
+        <span class="label">Message</span>
+        <div class="msg">${safeMsg}</div>
+
+        ${replyTo ? `<a class="btn" href="${replyHref}">Reply</a>` : ""}
+      </div>
+      <div class="footer">
+        This email came from your portfolio contact form.
+      </div>
+    </div>
+  </div>
+</body>
+</html>`);
+}
+
+function createLineReader(socket: import("tls").TLSSocket) {
+  let buffer = "";
+  const pending: {
+    resolve: (line: string) => void;
+    reject: (error: Error) => void;
+  }[] = [];
   const queued: string[] = [];
 
   const failPending = (error: Error) => {
@@ -47,38 +138,32 @@ function createLineReader(socket: import('tls').TLSSocket) {
     }
   };
 
-  socket.setEncoding('utf8');
+  socket.setEncoding("utf8");
 
-  socket.on('data', (chunk) => {
+  socket.on("data", (chunk) => {
     buffer += chunk;
     let index;
-    while ((index = buffer.indexOf('\r\n')) !== -1) {
+    while ((index = buffer.indexOf("\r\n")) !== -1) {
       const line = buffer.slice(0, index);
       buffer = buffer.slice(index + 2);
-      if (pending.length > 0) {
-        pending.shift()!.resolve(line);
-      } else {
-        queued.push(line);
-      }
+      if (pending.length > 0) pending.shift()!.resolve(line);
+      else queued.push(line);
     }
   });
 
-  socket.on('error', (error) => {
-    failPending(error instanceof Error ? error : new Error(String(error)));
-  });
-
-  socket.on('end', () => {
-    failPending(new Error('SMTP connection ended unexpectedly.'));
-  });
-
-  socket.on('close', () => {
-    failPending(new Error('SMTP connection closed unexpectedly.'));
-  });
-
-  socket.on('timeout', () => {
-    const timeoutError = new Error('SMTP connection timed out.');
-    failPending(timeoutError);
-    socket.destroy(timeoutError);
+  socket.on("error", (e) =>
+    failPending(e instanceof Error ? e : new Error(String(e)))
+  );
+  socket.on("end", () =>
+    failPending(new Error("SMTP connection ended unexpectedly."))
+  );
+  socket.on("close", () =>
+    failPending(new Error("SMTP connection closed unexpectedly."))
+  );
+  socket.on("timeout", () => {
+    const err = new Error("SMTP connection timed out.");
+    failPending(err);
+    socket.destroy(err);
   });
 
   return () =>
@@ -91,94 +176,112 @@ function createLineReader(socket: import('tls').TLSSocket) {
     });
 }
 
-async function write(socket: import('tls').TLSSocket, data: string) {
+async function write(socket: import("tls").TLSSocket, data: string) {
   await new Promise<void>((resolve, reject) => {
     if (!socket.writable) {
-      reject(new Error('SMTP connection is not writable.'));
+      reject(new Error("SMTP connection is not writable."));
       return;
     }
-
     const cleanup = () => {
-      socket.off('error', onError);
-      socket.off('drain', onDrain);
+      socket.off("error", onError);
+      socket.off("drain", onDrain);
     };
-
     const onError = (error: unknown) => {
       cleanup();
       reject(error instanceof Error ? error : new Error(String(error)));
     };
-
     const onDrain = () => {
       cleanup();
       resolve();
     };
-
-    socket.on('error', onError);
-    const flushed = socket.write(data, 'utf8');
-    if (flushed) {
-      process.nextTick(onDrain);
-    } else {
-      socket.once('drain', onDrain);
-    }
+    socket.on("error", onError);
+    const flushed = socket.write(data, "utf8");
+    if (flushed) process.nextTick(onDrain);
+    else socket.once("drain", onDrain);
   });
 }
 
-async function writeLine(socket: import('tls').TLSSocket, line: string) {
+async function writeLine(socket: import("tls").TLSSocket, line: string) {
   await write(socket, `${line}\r\n`);
 }
 
 async function readResponse(
   readLine: () => Promise<string>,
   expectedCode: string,
-  commandLabel: string,
+  commandLabel: string
 ) {
   const lines: string[] = [];
   while (true) {
     const line = await readLine();
     lines.push(line);
-    if (line.length < 4) {
-      continue;
-    }
+    if (line.length < 4) continue;
     const code = line.slice(0, 3);
     const delimiter = line.charAt(3);
-    if (delimiter === ' ') {
+    if (delimiter === " ") {
       if (code !== expectedCode) {
         throw new Error(
-          `Unexpected SMTP response while executing ${commandLabel}: ${lines.join('\n')}`,
+          `Unexpected SMTP response while executing ${commandLabel}: ${lines.join(
+            "\n"
+          )}`
         );
       }
-      return lines.join('\n');
+      return lines.join("\n");
     }
   }
 }
 
 async function sendCommand(
-  socket: import('tls').TLSSocket,
+  socket: import("tls").TLSSocket,
   readLine: () => Promise<string>,
   command: string,
   expectedCode: string,
-  label: string,
+  label: string
 ) {
   await writeLine(socket, command);
   return readResponse(readLine, expectedCode, label);
 }
 
-export async function sendContactEmail({ name, email, message }: ContactMessage): Promise<void> {
+export async function sendContactEmail({
+  name,
+  email,
+  message,
+}: ContactMessage): Promise<void> {
   const fromEmail = process.env.APP_FROM_EMAIL;
   const fromPassword = process.env.APP_FROM_PASSWORD;
   const toEmail = process.env.APP_TO_EMAIL;
 
   if (!fromEmail || !fromPassword || !toEmail) {
-    throw new EmailConfigurationError('Email environment variables are not fully configured.');
+    throw new EmailConfigurationError(
+      "Email environment variables are not fully configured."
+    );
   }
 
-  const sanitizedName = sanitizeHeaderValue(name, 'Portfolio Visitor');
+  const sanitizedName = sanitizeHeaderValue(name, "Portfolio Visitor");
   const replyTo = sanitizeEmail(email);
-  const subject = `New portfolio message from ${sanitizedName}`;
-  const composedBody = `You received a new message through your portfolio contact form.\n\nName: ${sanitizedName}\nEmail: ${
-    replyTo || 'not provided'
-  }\n\nMessage:\n${message.trim()}`;
-  const messageBody = normalizeMessageBody(composedBody);
+  const subject = `[Portfolio] New message from ${sanitizedName}`;
+
+  // Build bodies
+  const textBody = buildPlainText(sanitizedName, replyTo, message);
+  const htmlBody = buildHtml(sanitizedName, replyTo, message);
+
+  // MIME body
+  const boundary = `b1_${Date.now().toString(36)}`;
+  const mimeBody = [
+    `--${boundary}`,
+    "Content-Type: text/plain; charset=utf-8",
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    textBody,
+    "",
+    `--${boundary}`,
+    "Content-Type: text/html; charset=utf-8",
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    htmlBody,
+    "",
+    `--${boundary}--`,
+    "",
+  ].join("\r\n");
 
   const socket = connect({
     host: SMTP_HOST,
@@ -188,56 +291,73 @@ export async function sendContactEmail({ name, email, message }: ContactMessage)
 
   socket.setTimeout(15000);
 
-  const connectPromise = new Promise<void>((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const cleanup = () => {
-      socket.off('secureConnect', onConnect);
-      socket.off('error', onError);
+      socket.off("secureConnect", onConnect);
+      socket.off("error", onError);
     };
-
     const onConnect = () => {
       cleanup();
       resolve();
     };
-
     const onError = (error: unknown) => {
       cleanup();
       reject(error instanceof Error ? error : new Error(String(error)));
     };
-
-    socket.once('secureConnect', onConnect);
-    socket.once('error', onError);
+    socket.once("secureConnect", onConnect);
+    socket.once("error", onError);
   });
-
-  await connectPromise;
 
   const readLine = createLineReader(socket);
 
   try {
-    await readResponse(readLine, '220', 'initial greeting');
-    await sendCommand(socket, readLine, 'EHLO portfolio.local', '250', 'EHLO');
-    await sendCommand(socket, readLine, 'AUTH LOGIN', '334', 'AUTH LOGIN');
-    await sendCommand(socket, readLine, toBase64(fromEmail), '334', 'username authentication');
-    await sendCommand(socket, readLine, toBase64(fromPassword), '235', 'password authentication');
-    await sendCommand(socket, readLine, `MAIL FROM:<${fromEmail}>`, '250', 'MAIL FROM');
-    await sendCommand(socket, readLine, `RCPT TO:<${toEmail}>`, '250', 'RCPT TO');
-    await sendCommand(socket, readLine, 'DATA', '354', 'DATA');
+    await readResponse(readLine, "220", "initial greeting");
+    await sendCommand(socket, readLine, "EHLO portfolio.local", "250", "EHLO");
+    await sendCommand(socket, readLine, "AUTH LOGIN", "334", "AUTH LOGIN");
+    await sendCommand(
+      socket,
+      readLine,
+      toBase64(fromEmail),
+      "334",
+      "username authentication"
+    );
+    await sendCommand(
+      socket,
+      readLine,
+      toBase64(fromPassword),
+      "235",
+      "password authentication"
+    );
+    await sendCommand(
+      socket,
+      readLine,
+      `MAIL FROM:<${fromEmail}>`,
+      "250",
+      "MAIL FROM"
+    );
+    await sendCommand(
+      socket,
+      readLine,
+      `RCPT TO:<${toEmail}>`,
+      "250",
+      "RCPT TO"
+    );
+    await sendCommand(socket, readLine, "DATA", "354", "DATA");
 
     const headers = [
-      `From: "${sanitizedName}" <${fromEmail}>`,
+      `From: "Portfolio" <${fromEmail}>`,
       `To: ${toEmail}`,
       `Reply-To: ${replyTo || fromEmail}`,
       `Subject: ${sanitizeHeaderValue(subject)}`,
       `Date: ${new Date().toUTCString()}`,
-      'MIME-Version: 1.0',
-      'Content-Type: text/plain; charset=utf-8',
-      'Content-Transfer-Encoding: 8bit',
-      '',
-      messageBody,
-    ].join('\r\n');
+      "MIME-Version: 1.0",
+      `Content-Type: multipart/alternative; boundary="${boundary}"`,
+      "",
+    ].join("\r\n");
 
-    await write(socket, `${headers}\r\n.\r\n`);
-    await readResponse(readLine, '250', 'message delivery');
-    await sendCommand(socket, readLine, 'QUIT', '221', 'QUIT');
+    await write(socket, `${headers}${mimeBody}\r\n.\r\n`);
+    await readResponse(readLine, "250", "message delivery");
+    await sendCommand(socket, readLine, "QUIT", "221", "QUIT");
   } finally {
     socket.end();
   }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -82,7 +82,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
     .label{display:block;font-size:12px;color:#64748b;margin-bottom:4px;text-transform:uppercase;letter-spacing:.02em;}
     .value{font-size:15px;color:#0f172a;margin:0 0 16px;}
     .msg{padding:14px;border:1px solid #e5e7eb;border-radius:8px;background:#fafafa;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
-    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#2563eb;color:#ffffff;font-weight:600;}
+    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#000000;color:#ffffff;font-weight:600;}
     .footer{padding:16px 24px;color:#64748b;font-size:12px;border-top:1px solid #e5e7eb;background:#fafafa;}
     @media (prefers-color-scheme: dark){
       body{background:#0b0c10;color:#e5e7eb;}
@@ -91,6 +91,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
       .body{color:#e5e7eb;}
       .value{color:#e5e7eb;}
       .msg{background:#0f172a;border-color:#1f2937;color:#e5e7eb;}
+      .btn{background:#ffffff;color:#000000;}
       .footer{background:#0f172a;border-top-color:#1f2937;color:#9ca3af;}
     }
   </style>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -63,8 +63,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
   const safeMsg = escapeHtml(msg.trim()).replace(/\r?\n/g, "<br>");
   const replyHref = replyTo ? `mailto:${replyTo}` : "#";
 
-  return normalizeMessageBody(`\
-<!doctype html>
+  return normalizeMessageBody(`<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -82,7 +81,7 @@ function buildHtml(name: string, replyTo: string, msg: string) {
     .label{display:block;font-size:12px;color:#64748b;margin-bottom:4px;text-transform:uppercase;letter-spacing:.02em;}
     .value{font-size:15px;color:#0f172a;margin:0 0 16px;}
     .msg{padding:14px;border:1px solid #e5e7eb;border-radius:8px;background:#fafafa;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
-    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:600;border:1px solid #0f172a;color:#0f172a;background:transparent;}
+    .btn{display:inline-block;margin-top:16px;padding:10px 16px;border-radius:8px;text-decoration:none;background:#ffffff;color:#111827;font-weight:600;border:1px solid #e5e7eb;}
     .footer{padding:16px 24px;color:#64748b;font-size:12px;border-top:1px solid #e5e7eb;background:#fafafa;}
     @media (prefers-color-scheme: dark){
       body{background:#0b0c10;color:#e5e7eb;}
@@ -91,8 +90,8 @@ function buildHtml(name: string, replyTo: string, msg: string) {
       .body{color:#e5e7eb;}
       .value{color:#e5e7eb;}
       .msg{background:#0f172a;border-color:#1f2937;color:#e5e7eb;}
-      .btn{color:#e5e7eb;border-color:#e5e7eb;background:transparent;}
       .footer{background:#0f172a;border-top-color:#1f2937;color:#9ca3af;}
+      .btn{background:#000000;color:#ffffff;border-color:#1f2937;}
     }
   </style>
 </head>
@@ -261,11 +260,9 @@ export async function sendContactEmail({
   const replyTo = sanitizeEmail(email);
   const subject = `[Portfolio] New message from ${sanitizedName}`;
 
-  // Build bodies
   const textBody = buildPlainText(sanitizedName, replyTo, message);
   const htmlBody = buildHtml(sanitizedName, replyTo, message);
 
-  // MIME body
   const boundary = `b1_${Date.now().toString(36)}`;
   const mimeBody = [
     `--${boundary}`,


### PR DESCRIPTION
## Summary
- add a contact form to the home page that lets visitors submit their name, email, and message
- implement an API route that validates the payload and hands it off to the mailer
- build a Gmail SMTP mailer that connects with TLS using the configured environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1f6d5dd248327b5794342e6db8fa5