### PR TITLE
feat: enhance contact form editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@tiptap/react": "^2.8.0",
+    "@tiptap/starter-kit": "^2.8.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -6,6 +6,7 @@ interface ContactRequestBody {
   name?: unknown;
   email?: unknown;
   message?: unknown;
+  messageHtml?: unknown;
 }
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -13,7 +14,10 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 function validateRequest(body: ContactRequestBody) {
   const name = typeof body.name === 'string' ? body.name.trim() : '';
   const email = typeof body.email === 'string' ? body.email.trim() : '';
-  const message = typeof body.message === 'string' ? body.message.trim() : '';
+  const rawMessage = typeof body.message === 'string' ? body.message : '';
+  const normalizedMessage = rawMessage.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const message = normalizedMessage.trim();
+  const messageHtml = typeof body.messageHtml === 'string' ? body.messageHtml.trim() : '';
 
   if (!name) {
     return { error: 'Please provide your name.' } as const;
@@ -31,7 +35,11 @@ function validateRequest(body: ContactRequestBody) {
     return { error: 'Message is too long. Please keep it under 5000 characters.' } as const;
   }
 
-  return { name, email, message } as const;
+  if (messageHtml.length > 20000) {
+    return { error: 'Formatted message is too long. Please shorten it.' } as const;
+  }
+
+  return { name, email, message, messageHtml } as const;
 }
 
 export async function POST(request: Request) {

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -49,7 +49,14 @@ export default function ContactForm() {
     ],
     editorProps: {
       attributes: {
-        class: 'outline-none',
+        class: [
+          'min-h-[180px] w-full cursor-text px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
+          'focus:outline-none focus-visible:outline-none',
+          '[&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5',
+          '[&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-3 [&_p:last-child]:mb-0',
+          '[&_ul]:list-disc [&_ul]:pl-6',
+          '[&_blockquote]:border-l-2 [&_blockquote]:border-primary/40 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground',
+        ].join(' '),
       },
     },
     onCreate({ editor }) {
@@ -235,10 +242,7 @@ export default function ContactForm() {
                       Tell me about your project or question.
                     </span>
                   )}
-                  <EditorContent
-                    editor={editor}
-                    className="min-h-[180px] px-3 py-2 text-sm leading-6 text-foreground focus:outline-none [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:pl-6 [&_blockquote]:border-l-2 [&_blockquote]:border-primary/40 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground"
-                  />
+                  <EditorContent editor={editor} />
                 </>
               ) : (
                 <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -20,6 +20,8 @@ const NON_BREAKING_SPACE_REGEX = /\u00A0/g;
 const sanitizeEditorText = (value: string) =>
   value.replace(ZERO_WIDTH_SPACE_REGEX, '').replace(NON_BREAKING_SPACE_REGEX, ' ').trim();
 
+const WRAPPER_NODE_TYPES = new Set(['bulletList', 'orderedList', 'blockquote', 'listItem']);
+
 const nodeHasMeaningfulText = (node: JSONContent | null | undefined): boolean => {
   if (!node) {
     return false;
@@ -29,8 +31,20 @@ const nodeHasMeaningfulText = (node: JSONContent | null | undefined): boolean =>
     return true;
   }
 
-  if (Array.isArray(node.content)) {
-    return node.content.some((child) => nodeHasMeaningfulText(child));
+  if (node.type === 'hardBreak') {
+    return true;
+  }
+
+  if (!Array.isArray(node.content)) {
+    return false;
+  }
+
+  if (node.content.some((child) => nodeHasMeaningfulText(child))) {
+    return true;
+  }
+
+  if (node.type && WRAPPER_NODE_TYPES.has(node.type)) {
+    return node.content.length > 0;
   }
 
   return false;

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -303,7 +303,7 @@ export default function ContactForm() {
               {editor ? (
                 <>
                   {isEditorEmpty && (
-                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
+                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground/70">
                       Tell me about your project or question.
                     </span>
                   )}

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -261,7 +261,7 @@ export default function ContactForm() {
             required
             value={values.name}
             onChange={handleChange('name')}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
             placeholder="Juan Dela Cruz"
           />
         </div>
@@ -276,7 +276,7 @@ export default function ContactForm() {
             required
             value={values.email}
             onChange={handleChange('email')}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
             placeholder="you@example.com"
           />
         </div>
@@ -303,7 +303,7 @@ export default function ContactForm() {
               {editor ? (
                 <>
                   {isEditorEmpty && (
-                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground/70">
+                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
                       Tell me about your project or question.
                     </span>
                   )}

--- a/types/tiptap.d.ts
+++ b/types/tiptap.d.ts
@@ -15,6 +15,7 @@ declare module '@tiptap/react' {
     readonly isEmpty: boolean;
     getHTML(): string;
     getText(options?: { blockSeparator?: string }): string;
+    getJSON(): unknown;
     setEditable(editable: boolean): void;
     isActive(name: string): boolean;
     commands: {

--- a/types/tiptap.d.ts
+++ b/types/tiptap.d.ts
@@ -1,2 +1,55 @@
-declare module '@tiptap/react';
-declare module '@tiptap/starter-kit';
+declare module '@tiptap/react' {
+  import type { ComponentType } from 'react';
+
+  export interface CommandChain {
+    focus(): CommandChain;
+    toggleBold(): CommandChain;
+    toggleItalic(): CommandChain;
+    toggleBulletList(): CommandChain;
+    toggleOrderedList(): CommandChain;
+    toggleBlockquote(): CommandChain;
+    run(): boolean;
+  }
+
+  export interface Editor {
+    readonly isEmpty: boolean;
+    getHTML(): string;
+    getText(options?: { blockSeparator?: string }): string;
+    setEditable(editable: boolean): void;
+    isActive(name: string): boolean;
+    commands: {
+      clearContent(emitUpdate?: boolean): void;
+    };
+    chain(): CommandChain;
+    can(): {
+      chain(): CommandChain;
+    };
+  }
+
+  export interface UseEditorOptions {
+    extensions?: unknown[];
+    editorProps?: {
+      attributes?: Record<string, string>;
+    };
+    onCreate?(event: { editor: Editor }): void;
+    onUpdate?(event: { editor: Editor }): void;
+    onSelectionUpdate?(event: { editor: Editor }): void;
+  }
+
+  export function useEditor(options?: UseEditorOptions): Editor | null;
+
+  export interface EditorContentProps {
+    editor: Editor | null;
+    className?: string;
+  }
+
+  export const EditorContent: ComponentType<EditorContentProps>;
+}
+
+declare module '@tiptap/starter-kit' {
+  const StarterKit: {
+    configure(options?: Record<string, unknown>): unknown;
+  };
+
+  export default StarterKit;
+}

--- a/types/tiptap.d.ts
+++ b/types/tiptap.d.ts
@@ -1,0 +1,2 @@
+declare module '@tiptap/react';
+declare module '@tiptap/starter-kit';


### PR DESCRIPTION
## Summary
- replace the textarea in the contact form with a Tiptap-powered rich text editor, add formatting controls, and arrange the inputs responsively
- allow the contact API to receive optional formatted HTML alongside the plain message and enforce length limits
- sanitize rich text before building outgoing emails, update the email markup to display formatting cleanly, and add the new editor dependencies plus TypeScript stubs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d23c7473ac8327b8d371e66f18efdb