### PR TITLE
Convert contact form and navbar to card-based layout

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -3,6 +3,14 @@
 import { type ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { EditorContent, type Editor as TiptapEditor, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import type { LucideIcon } from 'lucide-react';
@@ -245,95 +253,105 @@ export default function ContactForm() {
     : [];
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="mx-auto flex max-w-3xl flex-col gap-6 rounded-lg border border-border bg-background p-6 shadow-sm"
-    >
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="flex flex-col gap-2">
-          <label htmlFor="name" className="text-sm font-medium text-foreground">
-            Your name
-          </label>
-          <input
-            id="name"
-            name="name"
-            type="text"
-            required
-            value={values.name}
-            onChange={handleChange('name')}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-            placeholder="Juan Dela Cruz"
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <label htmlFor="email" className="text-sm font-medium text-foreground">
-            Your email
-          </label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            required
-            value={values.email}
-            onChange={handleChange('email')}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-            placeholder="you@example.com"
-          />
-        </div>
-        <div className="flex flex-col gap-2 md:col-span-2">
-          <span className="text-sm font-medium text-foreground">How can I help?</span>
-          <div className="flex flex-col overflow-hidden rounded-md border border-input bg-background focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
-            <div className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/60 px-2 py-1">
-              {formattingOptions.map(({ label, icon: Icon, action, isActive, isDisabled }) => (
-                <button
-                  key={label}
-                  type="button"
-                  onClick={action}
-                  disabled={isSubmitting || isDisabled}
-                  aria-label={label}
-                  className={`inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-                    isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                  } ${isSubmitting || isDisabled ? 'opacity-50' : ''}`}
-                >
-                  <Icon className="h-4 w-4" />
-                </button>
-              ))}
+    <Card className="mx-auto w-full max-w-3xl">
+      <CardHeader>
+        <CardTitle>Let&apos;s work together</CardTitle>
+        <CardDescription>
+          Have a project in mind or just want to say hi? Share a few details and I&apos;ll get back to
+          you as soon as possible.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit} className="flex flex-col">
+        <CardContent className="flex flex-col gap-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="name" className="text-sm font-medium text-foreground">
+                Your name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                value={values.name}
+                onChange={handleChange('name')}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                placeholder="Juan Dela Cruz"
+              />
             </div>
-            <div className="relative">
-              {editor ? (
-                <>
-                  {isEditorEmpty && (
-                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
-                      Tell me about your project or question.
-                    </span>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="email" className="text-sm font-medium text-foreground">
+                Your email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                value={values.email}
+                onChange={handleChange('email')}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                placeholder="you@example.com"
+              />
+            </div>
+            <div className="flex flex-col gap-2 md:col-span-2">
+              <span className="text-sm font-medium text-foreground">How can I help?</span>
+              <div className="flex flex-col overflow-hidden rounded-md border border-input bg-background focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
+                <div className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/60 px-2 py-1">
+                  {formattingOptions.map(({ label, icon: Icon, action, isActive, isDisabled }) => (
+                    <button
+                      key={label}
+                      type="button"
+                      onClick={action}
+                      disabled={isSubmitting || isDisabled}
+                      aria-label={label}
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                        isActive
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      } ${isSubmitting || isDisabled ? 'opacity-50' : ''}`}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </button>
+                  ))}
+                </div>
+                <div className="relative">
+                  {editor ? (
+                    <>
+                      {isEditorEmpty && (
+                        <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
+                          Tell me about your project or question.
+                        </span>
+                      )}
+                      <EditorContent editor={editor} />
+                    </>
+                  ) : (
+                    <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>
                   )}
-                  <EditorContent editor={editor} />
-                </>
-              ) : (
-                <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>
-              )}
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
-      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
-          {isSubmitting ? 'Sending…' : 'Send message'}
-        </Button>
-        {status.message && (
-          <p
-            className={`text-sm ${
-              status.state === 'error'
-                ? 'text-destructive'
-                : status.state === 'success'
-                  ? 'text-emerald-600'
-                  : 'text-muted-foreground'
-            }`}
-          >
-            {status.message}
-          </p>
-        )}
-      </div>
-    </form>
+        </CardContent>
+        <CardFooter className="flex-col items-stretch gap-2 md:flex-row md:items-center md:justify-between">
+          <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
+            {isSubmitting ? 'Sending…' : 'Send message'}
+          </Button>
+          {status.message && (
+            <p
+              className={`text-sm ${
+                status.state === 'error'
+                  ? 'text-destructive'
+                  : status.state === 'success'
+                    ? 'text-emerald-600'
+                    : 'text-muted-foreground'
+              }`}
+            >
+              {status.message}
+            </p>
+          )}
+        </CardFooter>
+      </form>
+    </Card>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-xl border border-border bg-card text-card-foreground shadow",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  ),
+)
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  ),
+)
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ),
+)
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+)
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
 import {
     Sheet,
     SheetTrigger,
@@ -14,7 +15,6 @@ import { FaMoon, FaSun } from "react-icons/fa"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useThemeStore } from "@/lib/theme-store"
-import { Separator } from "@/components/ui/separator"
 
 const links = [
     { href: "/", label: "About" },
@@ -40,70 +40,73 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
     const currentTheme = mounted ? theme : initialTheme || theme
 
     return (
-        <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
-            <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
-                <div className="md:hidden">
-                    <Sheet>
-                        <SheetTrigger asChild>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="size-8"
-                                aria-label="Open menu"
-                            >
-                                <Menu className="h-5 w-5" />
-                            </Button>
-                        </SheetTrigger>
-                        <SheetContent side="left">
-                            <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
-                            <SheetDescription className="sr-only">
-                                Site navigation links
-                            </SheetDescription>
-                            <nav className="grid gap-4 py-4">
-                                {links.map((l) => (
-                                    <Button key={l.href} variant="ghost" asChild>
-                                        <Link href={l.href}>{l.label}</Link>
+        <header className="sticky top-0 z-40 w-full bg-background/60 backdrop-blur supports-[backdrop-filter]:bg-background/40">
+            <div className="mx-auto max-w-6xl px-4 py-3">
+                <Card className="flex h-14 w-full items-center justify-between gap-4 rounded-full border-border/60 bg-background/80 px-4 shadow-sm supports-[backdrop-filter]:bg-background/60">
+                    <div className="flex items-center gap-2">
+                        <div className="md:hidden">
+                            <Sheet>
+                                <SheetTrigger asChild>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="size-8"
+                                        aria-label="Open menu"
+                                    >
+                                        <Menu className="h-5 w-5" />
                                     </Button>
-                                ))}
-                            </nav>
-                        </SheetContent>
-                    </Sheet>
-                </div>
+                                </SheetTrigger>
+                                <SheetContent side="left">
+                                    <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
+                                    <SheetDescription className="sr-only">
+                                        Site navigation links
+                                    </SheetDescription>
+                                    <nav className="grid gap-4 py-4">
+                                        {links.map((l) => (
+                                            <Button key={l.href} variant="ghost" asChild>
+                                                <Link href={l.href}>{l.label}</Link>
+                                            </Button>
+                                        ))}
+                                    </nav>
+                                </SheetContent>
+                            </Sheet>
+                        </div>
 
-                <Link href="/" className="flex items-center gap-2 font-semibold">
-                    <div className="relative h-6 w-6">
-                        <Image
-                            src="/logo-dark.svg"
-                            alt="Logo"
-                            fill
-                            sizes="24px"
-                            className="object-contain dark:hidden"
-                        />
-                        <Image
-                            src="/logo-light.svg"
-                            alt="Logo"
-                            fill
-                            sizes="24px"
-                            className="hidden object-contain dark:block"
-                        />
+                        <Link href="/" className="flex items-center gap-2 font-semibold">
+                            <div className="relative h-6 w-6">
+                                <Image
+                                    src="/logo-dark.svg"
+                                    alt="Logo"
+                                    fill
+                                    sizes="24px"
+                                    className="object-contain dark:hidden"
+                                />
+                                <Image
+                                    src="/logo-light.svg"
+                                    alt="Logo"
+                                    fill
+                                    sizes="24px"
+                                    className="hidden object-contain dark:block"
+                                />
+                            </div>
+                        </Link>
                     </div>
-                </Link>
 
-                <nav className="hidden md:flex items-center gap-4">
-                    {links.map((l) => (
-                        <Button key={l.href} variant="ghost" asChild>
-                            <Link href={l.href}>{l.label}</Link>
+                    <nav className="hidden items-center gap-4 md:flex">
+                        {links.map((l) => (
+                            <Button key={l.href} variant="ghost" asChild>
+                                <Link href={l.href}>{l.label}</Link>
+                            </Button>
+                        ))}
+                    </nav>
+
+                    <div className="flex items-center gap-2">
+                        <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
+                            {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                         </Button>
-                    ))}
-                </nav>
-
-                <div className="flex items-center gap-2">
-                    <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
-                        {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
-                    </Button>
-                </div>
+                    </div>
+                </Card>
             </div>
-            <Separator />
         </header>
     )
 }


### PR DESCRIPTION
## Summary
- add a reusable Card UI primitive
- restyle the contact form using Card header/content/footer structure
- wrap the navbar controls in a Card for a cohesive elevated layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3813413e0832790bc551547033115