### PR TITLE
Wrap contact form in card layout

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -3,7 +3,7 @@
 import { type ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { EditorContent, type Editor as TiptapEditor, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import type { LucideIcon } from 'lucide-react';
@@ -248,7 +248,7 @@ export default function ContactForm() {
   return (
     <Card className="mx-auto max-w-3xl">
       <form onSubmit={handleSubmit} className="flex flex-col">
-        <CardContent className="space-y-6 p-6 pt-6 pb-0">
+        <CardContent className="space-y-6 p-6 pt-6">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="flex flex-col gap-2">
               <label htmlFor="name" className="text-sm font-medium text-foreground">
@@ -316,25 +316,25 @@ export default function ContactForm() {
               </div>
             </div>
           </div>
-          <div className="-mx-6 flex flex-col items-stretch gap-2 border-t border-border/60 bg-muted/40 px-6 py-4 md:flex-row md:items-center md:justify-between">
-            <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
-              {isSubmitting ? 'Sending…' : 'Send message'}
-            </Button>
-            {status.message && (
-              <p
-                className={`text-sm ${
-                  status.state === 'error'
-                    ? 'text-destructive'
-                    : status.state === 'success'
-                      ? 'text-emerald-600'
-                      : 'text-muted-foreground'
-                }`}
-              >
-                {status.message}
-              </p>
-            )}
-          </div>
         </CardContent>
+        <CardFooter className="flex-col items-stretch gap-2 border-t border-border/60 px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
+            {isSubmitting ? 'Sending…' : 'Send message'}
+          </Button>
+          {status.message && (
+            <p
+              className={`text-sm ${
+                status.state === 'error'
+                  ? 'text-destructive'
+                  : status.state === 'success'
+                    ? 'text-emerald-600'
+                    : 'text-muted-foreground'
+              }`}
+            >
+              {status.message}
+            </p>
+          )}
+        </CardFooter>
       </form>
     </Card>
   );

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -3,7 +3,7 @@
 import { type ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { EditorContent, type Editor as TiptapEditor, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import type { LucideIcon } from 'lucide-react';
@@ -248,7 +248,7 @@ export default function ContactForm() {
   return (
     <Card className="mx-auto max-w-3xl">
       <form onSubmit={handleSubmit} className="flex flex-col">
-        <CardContent className="p-6 pt-6">
+        <CardContent className="space-y-6 p-6 pt-6 pb-0">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="flex flex-col gap-2">
               <label htmlFor="name" className="text-sm font-medium text-foreground">
@@ -316,25 +316,25 @@ export default function ContactForm() {
               </div>
             </div>
           </div>
+          <div className="-mx-6 flex flex-col items-stretch gap-2 border-t border-border/60 bg-muted/40 px-6 py-4 md:flex-row md:items-center md:justify-between">
+            <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
+              {isSubmitting ? 'Sending…' : 'Send message'}
+            </Button>
+            {status.message && (
+              <p
+                className={`text-sm ${
+                  status.state === 'error'
+                    ? 'text-destructive'
+                    : status.state === 'success'
+                      ? 'text-emerald-600'
+                      : 'text-muted-foreground'
+                }`}
+              >
+                {status.message}
+              </p>
+            )}
+          </div>
         </CardContent>
-        <CardFooter className="flex-col items-stretch gap-2 border-t border-border/60 bg-muted/40 px-6 py-4 pt-4 md:flex-row md:items-center md:justify-between">
-          <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
-            {isSubmitting ? 'Sending…' : 'Send message'}
-          </Button>
-          {status.message && (
-            <p
-              className={`text-sm ${
-                status.state === 'error'
-                  ? 'text-destructive'
-                  : status.state === 'success'
-                    ? 'text-emerald-600'
-                    : 'text-muted-foreground'
-              }`}
-            >
-              {status.message}
-            </p>
-          )}
-        </CardFooter>
       </form>
     </Card>
   );

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -3,6 +3,7 @@
 import { type ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { EditorContent, type Editor as TiptapEditor, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import type { LucideIcon } from 'lucide-react';
@@ -245,95 +246,96 @@ export default function ContactForm() {
     : [];
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="mx-auto flex max-w-3xl flex-col gap-6 rounded-lg border border-border bg-background p-6 shadow-sm"
-    >
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="flex flex-col gap-2">
-          <label htmlFor="name" className="text-sm font-medium text-foreground">
-            Your name
-          </label>
-          <input
-            id="name"
-            name="name"
-            type="text"
-            required
-            value={values.name}
-            onChange={handleChange('name')}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-            placeholder="Juan Dela Cruz"
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <label htmlFor="email" className="text-sm font-medium text-foreground">
-            Your email
-          </label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            required
-            value={values.email}
-            onChange={handleChange('email')}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
-            placeholder="you@example.com"
-          />
-        </div>
-        <div className="flex flex-col gap-2 md:col-span-2">
-          <span className="text-sm font-medium text-foreground">How can I help?</span>
-          <div className="flex flex-col overflow-hidden rounded-md border border-input bg-background focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
-            <div className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/60 px-2 py-1">
-              {formattingOptions.map(({ label, icon: Icon, action, isActive, isDisabled }) => (
-                <button
-                  key={label}
-                  type="button"
-                  onClick={action}
-                  disabled={isSubmitting || isDisabled}
-                  aria-label={label}
-                  className={`inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-                    isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                  } ${isSubmitting || isDisabled ? 'opacity-50' : ''}`}
-                >
-                  <Icon className="h-4 w-4" />
-                </button>
-              ))}
+    <Card className="mx-auto max-w-3xl">
+      <form onSubmit={handleSubmit} className="flex flex-col">
+        <CardContent className="p-6 pt-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="name" className="text-sm font-medium text-foreground">
+                Your name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                value={values.name}
+                onChange={handleChange('name')}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                placeholder="Juan Dela Cruz"
+              />
             </div>
-            <div className="relative">
-              {editor ? (
-                <>
-                  {isEditorEmpty && (
-                    <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
-                      Tell me about your project or question.
-                    </span>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="email" className="text-sm font-medium text-foreground">
+                Your email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                value={values.email}
+                onChange={handleChange('email')}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                placeholder="you@example.com"
+              />
+            </div>
+            <div className="flex flex-col gap-2 md:col-span-2">
+              <span className="text-sm font-medium text-foreground">How can I help?</span>
+              <div className="flex flex-col overflow-hidden rounded-md border border-input bg-background focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
+                <div className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/60 px-2 py-1">
+                  {formattingOptions.map(({ label, icon: Icon, action, isActive, isDisabled }) => (
+                    <button
+                      key={label}
+                      type="button"
+                      onClick={action}
+                      disabled={isSubmitting || isDisabled}
+                      aria-label={label}
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                        isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      } ${isSubmitting || isDisabled ? 'opacity-50' : ''}`}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </button>
+                  ))}
+                </div>
+                <div className="relative">
+                  {editor ? (
+                    <>
+                      {isEditorEmpty && (
+                        <span className="pointer-events-none absolute left-3 top-2 text-sm text-muted-foreground">
+                          Tell me about your project or question.
+                        </span>
+                      )}
+                      <EditorContent editor={editor} />
+                    </>
+                  ) : (
+                    <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>
                   )}
-                  <EditorContent editor={editor} />
-                </>
-              ) : (
-                <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>
-              )}
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
-      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
-          {isSubmitting ? 'Sending…' : 'Send message'}
-        </Button>
-        {status.message && (
-          <p
-            className={`text-sm ${
-              status.state === 'error'
-                ? 'text-destructive'
-                : status.state === 'success'
-                  ? 'text-emerald-600'
-                  : 'text-muted-foreground'
-            }`}
-          >
-            {status.message}
-          </p>
-        )}
-      </div>
-    </form>
+        </CardContent>
+        <CardFooter className="flex-col items-stretch gap-2 border-t border-border/60 bg-muted/40 px-6 py-4 pt-4 md:flex-row md:items-center md:justify-between">
+          <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
+            {isSubmitting ? 'Sending…' : 'Send message'}
+          </Button>
+          {status.message && (
+            <p
+              className={`text-sm ${
+                status.state === 'error'
+                  ? 'text-destructive'
+                  : status.state === 'success'
+                    ? 'text-emerald-600'
+                    : 'text-muted-foreground'
+              }`}
+            >
+              {status.message}
+            </p>
+          )}
+        </CardFooter>
+      </form>
+    </Card>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  ),
+)
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  ),
+)
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  ),
+)
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  ),
+)
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  ),
+)
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+)
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -45,11 +45,4 @@ const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
 )
 CardContent.displayName = "CardContent"
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
-  ),
-)
-CardFooter.displayName = "CardFooter"
-
-export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
+export { Card, CardHeader, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -45,4 +45,11 @@ const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
 )
 CardContent.displayName = "CardContent"
 
-export { Card, CardHeader, CardTitle, CardDescription, CardContent }
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  ),
+)
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }


### PR DESCRIPTION
## Summary
- add a reusable Card UI component for consistent card styling
- wrap the contact form in the Card layout and update footer styling to match the card structure

## Testing
- `npm run lint` *(fails: missing `@eslint/eslintrc` because npm cannot download packages – registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d385811460832780fa5e3cd548704d