### PR TITLE
Improve card and navigation contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,57 +4,57 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 240 5% 96%;
+    --foreground: 240 10% 3.9%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 240 10% 3.9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5% 65%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem
+    --radius: 0.5rem;
   }
   .dark {
-    --background: 0 0% 3.9%;
+    --background: 240 10% 4%;
     --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
+    --card: 240 10% 8%;
     --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
+    --popover: 240 10% 8%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
+    --primary-foreground: 240 5.9% 10%;
+    --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --border: 240 3.7% 18%;
+    --input: 240 3.7% 18%;
+    --ring: 240 4.9% 83.1%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%
+    --chart-5: 340 75% 55%;
   }
 }
 

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -282,7 +282,7 @@ export default function ContactForm() {
             </div>
             <div className="flex flex-col gap-2 md:col-span-2">
               <span className="text-sm font-medium text-foreground">How can I help?</span>
-              <div className="flex flex-col overflow-hidden rounded-md border border-input bg-background focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
+              <div className="flex flex-col overflow-hidden rounded-md border border-input bg-card focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
                 <div className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/60 px-2 py-1">
                   {formattingOptions.map(({ label, icon: Icon, action, isActive, isDisabled }) => (
                     <button

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -14,7 +14,6 @@ import { FaMoon, FaSun } from "react-icons/fa"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useThemeStore } from "@/lib/theme-store"
-import { Separator } from "@/components/ui/separator"
 
 const links = [
     { href: "/", label: "About" },
@@ -40,7 +39,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
     const currentTheme = mounted ? theme : initialTheme || theme
 
     return (
-        <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
+        <header className="sticky top-0 z-40 w-full border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
                 <div className="md:hidden">
                     <Sheet>
@@ -103,7 +102,6 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                     </Button>
                 </div>
             </div>
-            <Separator />
         </header>
     )
 }


### PR DESCRIPTION
## Summary
- tune the global color tokens so cards stand out from the page background in light and dark themes
- update the contact form editor container to use the card surface color for consistent contrast
- give the navbar a translucent background with a subtle border to visually separate it from the page

## Testing
- npm run lint *(fails: required npm packages cannot be installed in this environment – registry returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d395775eb08327a57447ff7dae2aaf