### PR TITLE
Revamp theme colors for navbar and card surfaces

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,57 +4,57 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 210 40% 96%;
+    --foreground: 224 47% 11%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 224 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --popover-foreground: 224 47% 11%;
+    --primary: 226 70% 55%;
+    --primary-foreground: 210 40% 96%;
+    --secondary: 210 40% 92%;
+    --secondary-foreground: 224 47% 20%;
+    --muted: 210 40% 90%;
+    --muted-foreground: 222 24% 28%;
+    --accent: 210 40% 92%;
+    --accent-foreground: 224 47% 15%;
+    --destructive: 0 84% 58%;
+    --destructive-foreground: 210 40% 96%;
+    --border: 214 32% 88%;
+    --input: 214 32% 88%;
+    --ring: 226 70% 55%;
+    --chart-1: 226 70% 55%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 35 88% 62%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 58%;
     --radius: 0.5rem
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
+    --background: 224 71% 4%;
+    --foreground: 210 40% 98%;
+    --card: 222 47% 9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 47% 9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 213 89% 67%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 220 28% 18%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 220 28% 18%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 220 27% 20%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 62% 45%;
+    --destructive-foreground: 210 40% 96%;
+    --border: 220 27% 20%;
+    --input: 220 27% 20%;
+    --ring: 213 89% 67%;
+    --chart-1: 213 89% 67%;
     --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%
+    --chart-3: 35 78% 60%;
+    --chart-4: 280 65% 57%;
+    --chart-5: 340 75% 60%;
   }
 }
 
@@ -64,5 +64,14 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(circle at 20% 20%, hsl(var(--primary) / 0.12), transparent 55%),
+      radial-gradient(circle at 80% 0%, hsl(var(--accent) / 0.18), transparent 45%);
+    min-height: 100vh;
+  }
+  .dark body {
+    background-image:
+      radial-gradient(circle at 20% 20%, hsl(var(--primary) / 0.2), transparent 55%),
+      radial-gradient(circle at 80% 0%, hsl(var(--accent) / 0.32), transparent 45%);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,7 @@ export default async function RootLayout({
           `}
         </Script>
       </head>
-      <body className="font-sans" suppressHydrationWarning>
+      <body className="font-sans antialiased" suppressHydrationWarning>
         <Navbar initialTheme={cookieTheme} />
         <main>{children}</main>
       </body>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -6,7 +6,11 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      className={cn(
+        "relative overflow-hidden rounded-xl border border-border/60 bg-card text-card-foreground shadow-[0_20px_45px_-24px_rgba(15,23,42,0.35)] transition-all duration-300 hover:border-primary/40 hover:shadow-[0_35px_65px_-35px_rgba(37,99,235,0.35)] dark:border-border/50 dark:shadow-[0_30px_65px_-35px_rgba(8,10,26,0.75)]",
+        "before:pointer-events-none before:absolute before:inset-x-6 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-primary/40 before:to-transparent before:opacity-0 before:transition-all before:duration-300 before:content-[''] hover:before:opacity-100",
+        className,
+      )}
       {...props}
     />
   ),

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -14,7 +14,6 @@ import { FaMoon, FaSun } from "react-icons/fa"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useThemeStore } from "@/lib/theme-store"
-import { Separator } from "@/components/ui/separator"
 
 const links = [
     { href: "/", label: "About" },
@@ -40,8 +39,8 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
     const currentTheme = mounted ? theme : initialTheme || theme
 
     return (
-        <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
-            <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        <header className="sticky top-3 z-40 flex w-full justify-center px-4">
+            <div className="flex h-14 w-full max-w-6xl items-center justify-between gap-3 rounded-full border border-border/60 bg-background/80 px-4 shadow-[0_12px_35px_-22px_rgba(15,23,42,0.45)] backdrop-blur supports-[backdrop-filter]:bg-background/60 dark:border-border/50 dark:shadow-[0_20px_45px_-28px_rgba(8,10,26,0.75)]">
                 <div className="md:hidden">
                     <Sheet>
                         <SheetTrigger asChild>
@@ -61,7 +60,12 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                             </SheetDescription>
                             <nav className="grid gap-4 py-4">
                                 {links.map((l) => (
-                                    <Button key={l.href} variant="ghost" asChild>
+                                    <Button
+                                        key={l.href}
+                                        variant="ghost"
+                                        className="justify-start text-base font-medium text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                                        asChild
+                                    >
                                         <Link href={l.href}>{l.label}</Link>
                                     </Button>
                                 ))}
@@ -89,21 +93,30 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                     </div>
                 </Link>
 
-                <nav className="hidden md:flex items-center gap-4">
+                <nav className="hidden items-center gap-1.5 md:flex">
                     {links.map((l) => (
-                        <Button key={l.href} variant="ghost" asChild>
+                        <Button
+                            key={l.href}
+                            variant="ghost"
+                            className="text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                            asChild
+                        >
                             <Link href={l.href}>{l.label}</Link>
                         </Button>
                     ))}
                 </nav>
 
                 <div className="flex items-center gap-2">
-                    <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-9 rounded-full bg-muted/40 text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+                        onClick={toggleTheme}
+                    >
                         {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                     </Button>
                 </div>
             </div>
-            <Separator />
         </header>
     )
 }


### PR DESCRIPTION
## Summary
- refresh the design tokens to introduce softer light shades, deeper dark neutrals, and a radial background wash across the app shell
- elevate the card component with a pill-shaped border, accent highlight, and more atmospheric shadow depth
- restyle the navbar into a translucent pill with refined button states that align with the updated palette

## Testing
- npm run lint *(fails: missing @eslint/eslintrc because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48a48b0bc83279d642a61ac703d30