### PR TITLE
feat: refresh theming for navbar and contact card

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,57 +4,57 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 220 26% 97%;
+    --foreground: 222 47% 11%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem
+    --popover-foreground: 222 47% 11%;
+    --primary: 222 89% 60%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 220 18% 92%;
+    --secondary-foreground: 222 47% 12%;
+    --muted: 217 16% 88%;
+    --muted-foreground: 222 8% 38%;
+    --accent: 217 92% 95%;
+    --accent-foreground: 222 47% 12%;
+    --destructive: 356 75% 53%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 220 17% 88%;
+    --input: 220 17% 88%;
+    --ring: 222 89% 60%;
+    --chart-1: 221 83% 53%;
+    --chart-2: 151 55% 41%;
+    --chart-3: 29 94% 52%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 82% 60%;
+    --radius: 0.75rem;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
+    --background: 222 47% 7%;
+    --foreground: 210 40% 98%;
+    --card: 222 47% 12%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 47% 12%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 222 47% 12%;
+    --secondary: 223 29% 18%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 220 27% 15%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 217 27% 24%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 356 68% 55%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 223 26% 18%;
+    --input: 223 26% 18%;
+    --ring: 217 91% 68%;
+    --chart-1: 221 83% 53%;
+    --chart-2: 151 55% 41%;
+    --chart-3: 29 94% 52%;
     --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%
+    --chart-5: 340 82% 60%;
   }
 }
 
@@ -63,6 +63,16 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply min-h-screen bg-background text-foreground antialiased;
+    background-image:
+      radial-gradient(120% 120% at 0% 0%, hsl(217 91% 60% / 0.12), transparent 55%),
+      radial-gradient(120% 120% at 100% 0%, hsl(280 65% 65% / 0.08), transparent 55%);
+    background-repeat: no-repeat;
+  }
+  .dark body {
+    background-image:
+      radial-gradient(120% 120% at 0% 0%, hsl(217 91% 60% / 0.18), transparent 60%),
+      radial-gradient(120% 120% at 100% 0%, hsl(280 65% 60% / 0.14), transparent 60%),
+      linear-gradient(180deg, hsl(222 47% 9%), hsl(222 47% 5%));
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,9 +53,11 @@ export default async function RootLayout({
           `}
         </Script>
       </head>
-      <body className="font-sans" suppressHydrationWarning>
+      <body className="font-sans antialiased" suppressHydrationWarning>
         <Navbar initialTheme={cookieTheme} />
-        <main>{children}</main>
+        <main className="relative z-10 mx-auto w-full max-w-6xl px-4 py-12 md:px-6">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -246,9 +246,9 @@ export default function ContactForm() {
     : [];
 
   return (
-    <Card className="mx-auto max-w-3xl">
+    <Card className="mx-auto max-w-3xl backdrop-blur-sm">
       <form onSubmit={handleSubmit} className="flex flex-col">
-        <CardContent className="space-y-6 p-6 pt-6">
+        <CardContent className="relative z-10 space-y-6 p-8">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="flex flex-col gap-2">
               <label htmlFor="name" className="text-sm font-medium text-foreground">
@@ -261,7 +261,7 @@ export default function ContactForm() {
                 required
                 value={values.name}
                 onChange={handleChange('name')}
-                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                className="w-full rounded-xl border border-border/60 bg-white/80 px-3 py-2 text-sm text-foreground shadow-[0_18px_45px_-30px_rgba(15,23,42,0.45)] outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-white/[0.04]"
                 placeholder="Juan Dela Cruz"
               />
             </div>
@@ -276,14 +276,14 @@ export default function ContactForm() {
                 required
                 value={values.email}
                 onChange={handleChange('email')}
-                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
+                className="w-full rounded-xl border border-border/60 bg-white/80 px-3 py-2 text-sm text-foreground shadow-[0_18px_45px_-30px_rgba(15,23,42,0.45)] outline-none transition placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 dark:bg-white/[0.04]"
                 placeholder="you@example.com"
               />
             </div>
             <div className="flex flex-col gap-2 md:col-span-2">
               <span className="text-sm font-medium text-foreground">How can I help?</span>
-              <div className="flex flex-col overflow-hidden rounded-md border border-input bg-background focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
-                <div className="flex flex-wrap items-center gap-1 border-b border-border bg-muted/60 px-2 py-1">
+              <div className="flex flex-col overflow-hidden rounded-2xl border border-border/60 bg-white/80 shadow-[0_22px_50px_-35px_rgba(15,23,42,0.55)] backdrop-blur focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20 dark:bg-white/[0.03]">
+                <div className="flex flex-wrap items-center gap-1 border-b border-border/70 bg-muted/60 px-2 py-1 dark:bg-white/[0.02]">
                   {formattingOptions.map(({ label, icon: Icon, action, isActive, isDisabled }) => (
                     <button
                       key={label}
@@ -291,8 +291,8 @@ export default function ContactForm() {
                       onClick={action}
                       disabled={isSubmitting || isDisabled}
                       aria-label={label}
-                      className={`inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
-                        isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      className={`inline-flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                        isActive ? 'bg-primary/15 text-primary shadow-[0_10px_30px_-20px_rgba(46,125,255,0.65)]' : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
                       } ${isSubmitting || isDisabled ? 'opacity-50' : ''}`}
                     >
                       <Icon className="h-4 w-4" />
@@ -317,8 +317,12 @@ export default function ContactForm() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex-col items-stretch gap-2 border-t border-border/60 px-6 py-4 md:flex-row md:items-center md:justify-between">
-          <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
+        <CardFooter className="flex-col items-stretch gap-2 border-t border-border/60 bg-muted/60 px-8 py-6 backdrop-blur-md dark:bg-white/[0.02] md:flex-row md:items-center md:justify-between">
+          <Button
+            type="submit"
+            disabled={isSubmitting || !editor}
+            className="w-full justify-center rounded-full bg-gradient-to-r from-primary via-primary/90 to-primary/80 shadow-[0_20px_45px_-20px_rgba(46,125,255,0.65)] hover:from-primary/95 hover:via-primary/90 hover:to-primary/80 md:w-auto"
+          >
             {isSubmitting ? 'Sending…' : 'Send message'}
           </Button>
           {status.message && (

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -6,7 +6,10 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      className={cn(
+        "group relative overflow-hidden rounded-2xl border border-border/60 bg-card text-card-foreground shadow-[0_20px_50px_-25px_rgba(15,23,42,0.45)] transition-all duration-300 before:pointer-events-none before:absolute before:inset-px before:-z-10 before:rounded-[inherit] before:border before:border-white/40 before:bg-gradient-to-br before:from-white/60 before:via-white/10 before:to-transparent before:content-[''] dark:before:border-white/10 hover:border-primary/50 hover:shadow-[0_30px_60px_-20px_rgba(46,125,255,0.55)]",
+        className,
+      )}
       {...props}
     />
   ),

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -14,7 +14,6 @@ import { FaMoon, FaSun } from "react-icons/fa"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useThemeStore } from "@/lib/theme-store"
-import { Separator } from "@/components/ui/separator"
 
 const links = [
     { href: "/", label: "About" },
@@ -40,8 +39,8 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
     const currentTheme = mounted ? theme : initialTheme || theme
 
     return (
-        <header className="sticky top-0 z-40 w-full bg-background/80 backdrop-blur">
-            <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        <header className="sticky top-0 z-40 w-full border-b border-border/60 bg-background/70 shadow-[0_1px_0_hsla(0,0%,100%,0.6)_inset,0_18px_45px_-30px_rgba(15,23,42,0.65)] backdrop-blur-xl transition-colors dark:shadow-[0_1px_0_rgba(255,255,255,0.06)_inset,0_18px_45px_-30px_rgba(0,0,0,0.65)]">
+            <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-3 px-4 md:px-6">
                 <div className="md:hidden">
                     <Sheet>
                         <SheetTrigger asChild>
@@ -54,14 +53,19 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                                 <Menu className="h-5 w-5" />
                             </Button>
                         </SheetTrigger>
-                        <SheetContent side="left">
+                        <SheetContent side="left" className="w-72 border-border/60 bg-background/95 backdrop-blur-xl">
                             <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
                             <SheetDescription className="sr-only">
                                 Site navigation links
                             </SheetDescription>
-                            <nav className="grid gap-4 py-4">
+                            <nav className="grid gap-2 py-4">
                                 {links.map((l) => (
-                                    <Button key={l.href} variant="ghost" asChild>
+                                    <Button
+                                        key={l.href}
+                                        variant="ghost"
+                                        className="justify-start rounded-xl bg-muted/40 text-foreground shadow-[0_18px_40px_-35px_rgba(15,23,42,0.55)] hover:bg-accent/60 hover:text-foreground dark:bg-white/[0.04]"
+                                        asChild
+                                    >
                                         <Link href={l.href}>{l.label}</Link>
                                     </Button>
                                 ))}
@@ -89,21 +93,30 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                     </div>
                 </Link>
 
-                <nav className="hidden md:flex items-center gap-4">
+                <nav className="hidden md:flex items-center gap-1 rounded-full border border-border/60 bg-background/60 px-1 py-1 shadow-[0_12px_35px_-24px_rgba(15,23,42,0.75)] transition-colors dark:bg-background/40">
                     {links.map((l) => (
-                        <Button key={l.href} variant="ghost" asChild>
+                        <Button
+                            key={l.href}
+                            variant="ghost"
+                            className="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground data-[state=active]:bg-accent data-[state=active]:text-foreground"
+                            asChild
+                        >
                             <Link href={l.href}>{l.label}</Link>
                         </Button>
                     ))}
                 </nav>
 
                 <div className="flex items-center gap-2">
-                    <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-9 rounded-full border border-border/40 bg-background/70 shadow-[0_10px_30px_-20px_rgba(15,23,42,0.75)] transition-transform hover:-translate-y-0.5 hover:border-primary/40 hover:bg-transparent hover:text-primary"
+                        onClick={toggleTheme}
+                    >
                         {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                     </Button>
                 </div>
             </div>
-            <Separator />
         </header>
     )
 }


### PR DESCRIPTION
## Summary
- retune the design tokens and backgrounds to give the app a softer vercel-style glow
- restyle the navbar, mobile sheet, and contact form card with glassmorphism-inspired accents
- center the main content container to keep the new theming focused on the portfolio sections

## Testing
- npm run lint *(fails: missing @eslint/eslintrc because npm install is blocked by registry 403 in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48a48b0bc83279d642a61ac703d30