### PR TITLE
Fix contact form editor overflow

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -307,7 +307,10 @@ export default function ContactForm() {
                           Tell me about your project or question.
                         </span>
                       )}
-                      <EditorContent editor={editor} />
+                      <EditorContent
+                        editor={editor}
+                        className="min-h-[9rem] max-h-64 overflow-y-auto px-3 py-2 text-sm leading-6 focus:outline-none focus-visible:outline-none"
+                      />
                     </>
                   ) : (
                     <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>


### PR DESCRIPTION
## Summary
- constrain the contact form message editor height so long inputs scroll instead of growing the layout
- preserve comfortable padding and typography inside the editor content area

## Testing
- npm install *(fails: 403 Forbidden fetching @tiptap/react)*

------
https://chatgpt.com/codex/tasks/task_e_68d61510fcc48327814b8ce1b72c26c9