### PR TITLE
Limit contact form editor height

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -108,7 +108,7 @@ export default function ContactForm() {
     editorProps: {
       attributes: {
         class: [
-          'h-64 w-full cursor-text overflow-y-auto px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
+          'h-56 w-full cursor-text overflow-y-auto px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
           'focus:outline-none focus-visible:outline-none',
           '[&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5',
           '[&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-3 [&_p:last-child]:mb-0',

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -108,7 +108,7 @@ export default function ContactForm() {
     editorProps: {
       attributes: {
         class: [
-          'min-h-[180px] max-h-64 w-full cursor-text overflow-y-auto px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
+          'h-64 w-full cursor-text overflow-y-auto px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
           'focus:outline-none focus-visible:outline-none',
           '[&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5',
           '[&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-3 [&_p:last-child]:mb-0',

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -108,7 +108,7 @@ export default function ContactForm() {
     editorProps: {
       attributes: {
         class: [
-          'min-h-[180px] w-full cursor-text px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
+          'min-h-[180px] max-h-64 w-full cursor-text overflow-y-auto px-3 py-2 text-sm leading-6 text-foreground caret-primary outline-none',
           'focus:outline-none focus-visible:outline-none',
           '[&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5',
           '[&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-3 [&_p:last-child]:mb-0',


### PR DESCRIPTION
## Summary
- limit the contact form rich text editor height so long messages scroll inside the input instead of expanding the card

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d61510fcc48327814b8ce1b72c26c9