### PR TITLE
Replace contact form editor loading text with skeleton placeholder

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -310,7 +310,12 @@ export default function ContactForm() {
                       <EditorContent editor={editor} />
                     </>
                   ) : (
-                    <div className="px-3 py-2 text-sm text-muted-foreground">Loading editor…</div>
+                    <div
+                      aria-hidden
+                      className="h-56 w-full cursor-text overflow-y-auto px-3 py-2"
+                    >
+                      <div className="h-full w-full animate-pulse rounded-md bg-muted/60" />
+                    </div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace the contact form editor's loading text with a skeleton-style placeholder to maintain layout without extra messaging

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d61a302a0c83279a929a795584afef