### PR TITLE
Add projects showcase section with placeholder artwork

### DIFF
--- a/public/projects/community-learning.svg
+++ b/public/projects/community-learning.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title>Community learning illustration</title>
+  <desc>People collaborating around a shared device</desc>
+  <defs>
+    <linearGradient id="sunset" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#ec4899" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="#0f172a" />
+  <rect x="32" y="48" width="576" height="264" rx="40" fill="url(#sunset)" opacity="0.6" />
+  <g transform="translate(200 120)">
+    <path d="M60 140c-24 0-44-20-44-44s20-44 44-44 44 20 44 44-20 44-44 44z" fill="rgba(248,250,252,0.9)" />
+    <path d="M60 68c-24 0-44-20-44-44S36 0 60 0s44 20 44 44-20 44-44 44z" fill="#f8fafc" opacity="0.7" />
+    <rect x="24" y="132" width="72" height="16" rx="8" fill="#0f172a" opacity="0.4" />
+  </g>
+  <g transform="translate(340 120)">
+    <rect x="-32" y="24" width="192" height="120" rx="28" fill="rgba(15,23,42,0.75)" />
+    <rect x="-20" y="36" width="168" height="96" rx="20" fill="#f8fafc" opacity="0.85" />
+    <rect x="-4" y="56" width="64" height="12" rx="6" fill="#0f172a" opacity="0.6" />
+    <rect x="-4" y="76" width="112" height="12" rx="6" fill="#ec4899" opacity="0.8" />
+    <rect x="-4" y="96" width="88" height="12" rx="6" fill="#f97316" opacity="0.8" />
+  </g>
+  <circle cx="520" cy="120" r="40" fill="rgba(248,250,252,0.9)" />
+  <circle cx="520" cy="120" r="24" fill="#0f172a" opacity="0.6" />
+  <rect x="480" y="220" width="120" height="24" rx="12" fill="#f8fafc" opacity="0.85" />
+</svg>

--- a/public/projects/data-insights.svg
+++ b/public/projects/data-insights.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title>Data insights illustration</title>
+  <desc>Stylized charts and graphs showing analytics data</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#14b8a6" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="#020817" />
+  <rect x="40" y="40" width="560" height="280" rx="32" fill="url(#bg)" opacity="0.7" />
+  <g transform="translate(100 90)">
+    <rect x="0" y="80" width="60" height="120" rx="12" fill="rgba(15,23,42,0.55)" />
+    <rect x="80" y="40" width="60" height="160" rx="12" fill="rgba(15,23,42,0.7)" />
+    <rect x="160" y="0" width="60" height="200" rx="12" fill="#f8fafc" opacity="0.85" />
+    <polyline points="0,180 60,120 120,140 180,80 240,100" fill="none" stroke="#fbbf24" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="0" cy="180" r="8" fill="#fbbf24" />
+    <circle cx="60" cy="120" r="8" fill="#fbbf24" />
+    <circle cx="120" cy="140" r="8" fill="#fbbf24" />
+    <circle cx="180" cy="80" r="8" fill="#fbbf24" />
+    <circle cx="240" cy="100" r="8" fill="#fbbf24" />
+  </g>
+  <rect x="360" y="120" width="180" height="60" rx="16" fill="rgba(248,250,252,0.9)" />
+  <rect x="380" y="136" width="96" height="12" rx="6" fill="#1d4ed8" opacity="0.8" />
+  <rect x="380" y="156" width="72" height="12" rx="6" fill="#0f172a" opacity="0.8" />
+</svg>

--- a/public/projects/immersive-design.svg
+++ b/public/projects/immersive-design.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title>Immersive design system abstract illustration</title>
+  <desc>Colorful geometric shapes layered over a gradient background</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+    <linearGradient id="accent" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a855f7" />
+      <stop offset="100%" stop-color="#f59e0b" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#gradient)" rx="32" />
+  <circle cx="160" cy="120" r="72" fill="rgba(255, 255, 255, 0.16)" />
+  <rect x="360" y="80" width="160" height="120" rx="24" fill="rgba(255,255,255,0.18)" />
+  <path d="M120 260h220l-60 60H60z" fill="rgba(15,23,42,0.2)" />
+  <path d="M420 220c-44 0-80 36-80 80h160c0-44-36-80-80-80z" fill="url(#accent)" opacity="0.75" />
+  <rect x="260" y="120" width="120" height="48" rx="12" fill="rgba(15,23,42,0.35)" />
+  <rect x="280" y="136" width="80" height="16" rx="8" fill="#f8fafc" opacity="0.9" />
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 import ContactForm from "@/components/contact-form";
+import ProjectsSection from "@/components/projects-section";
 
 export default function Home() {
   return (
     <main>
+      <ProjectsSection />
       <ContactForm />
     </main>
   );

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -1,0 +1,101 @@
+import Image from "next/image";
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+const projects = [
+  {
+    title: "Immersive Design System",
+    description:
+      "A modular design system crafted for a distributed product team, focused on rapid prototyping and consistent hand-offs.",
+    imageSrc: "/projects/immersive-design.svg",
+    imageAlt: "Abstract shapes representing a design system dashboard",
+    technologies: ["Figma", "React", "Storybook"],
+    link: "https://example.com/immersive-design-system",
+    linkLabel: "View case study",
+  },
+  {
+    title: "Data Insights Portal",
+    description:
+      "A responsive analytics portal that visualizes customer KPIs and integrates with real-time reporting pipelines.",
+    imageSrc: "/projects/data-insights.svg",
+    imageAlt: "Stylized charts and graphs symbolizing an analytics portal",
+    technologies: ["Next.js", "TypeScript", "D3.js"],
+    link: "https://example.com/data-insights-portal",
+    linkLabel: "Explore dashboard",
+  },
+  {
+    title: "Community Learning Hub",
+    description:
+      "An accessible learning platform featuring curated courses, collaborative study rooms, and dynamic progress tracking.",
+    imageSrc: "/projects/community-learning.svg",
+    imageAlt: "Illustration of people collaborating around a laptop",
+    technologies: ["Node.js", "PostgreSQL", "Tailwind CSS"],
+    link: "https://example.com/community-learning-hub",
+    linkLabel: "See product tour",
+  },
+] as const;
+
+const linkClasses =
+  "inline-flex items-center gap-2 text-sm font-medium text-primary transition hover:text-primary/80";
+
+const badgeClasses =
+  "rounded-full bg-muted px-3 py-1 text-xs font-medium tracking-wide text-muted-foreground";
+
+export default function ProjectsSection() {
+  return (
+    <section aria-labelledby="projects-heading" className="bg-muted/30 py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto mb-12 max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary">Selected Work</p>
+          <h2 id="projects-heading" className="mt-3 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Projects
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            A snapshot of multidisciplinary collaborations ranging from scalable platforms to immersive digital experiences.
+          </p>
+        </div>
+        <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+          {projects.map((project) => (
+            <Card key={project.title} className="flex h-full flex-col overflow-hidden">
+              <div className="relative h-48 w-full bg-muted">
+                <Image
+                  alt={project.imageAlt}
+                  src={project.imageSrc}
+                  fill
+                  sizes="(min-width: 1280px) 360px, (min-width: 768px) 45vw, 90vw"
+                  className="object-cover"
+                />
+              </div>
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-xl font-semibold">{project.title}</CardTitle>
+                <p className="text-sm text-muted-foreground">{project.description}</p>
+              </CardHeader>
+              <CardContent className="mt-auto flex flex-wrap gap-2">
+                {project.technologies.map((technology) => (
+                  <span className={badgeClasses} key={technology}>
+                    {technology}
+                  </span>
+                ))}
+              </CardContent>
+              <CardFooter>
+                <a
+                  aria-label={project.linkLabel}
+                  className={linkClasses}
+                  href={project.link}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {project.linkLabel}
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                    <path d="M7 17 17 7" strokeLinecap="round" strokeLinejoin="round" />
+                    <path d="M7 7h10v10" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </a>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a ProjectsSection component that highlights three representative projects with descriptions, tech stacks, and external links
- include temporary SVG artwork for each project and render the new section on the home page before the contact form

## Testing
- npm run lint *(fails: missing npm dependency due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d63ae42b4c8327b23dfa426865fe1a