### PR TITLE
Add projects section to home page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 import ContactForm from "@/components/contact-form";
+import ProjectsSection from "@/components/projects-section";
 
 export default function Home() {
   return (
-    <main>
+    <main className="space-y-24">
+      <ProjectsSection />
       <ContactForm />
     </main>
   );

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -1,0 +1,124 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+type Project = {
+  title: string;
+  description: string;
+  image: {
+    src: string;
+    alt: string;
+  };
+  technologies: string[];
+  href: string;
+  hrefLabel: string;
+};
+
+const projects: Project[] = [
+  {
+    title: "Atlas Insights Dashboard",
+    description:
+      "An interactive analytics dashboard that tracks campaign KPIs, featuring real-time charts, role-based views, and configurable reporting widgets tailored for marketing teams.",
+    image: {
+      src: "https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80",
+      alt: "Laptop displaying a data analytics dashboard interface.",
+    },
+    technologies: ["Next.js", "TypeScript", "Tailwind CSS"],
+    href: "https://example.com/atlas-insights",
+    hrefLabel: "View case study",
+  },
+  {
+    title: "Aurora Commerce Platform",
+    description:
+      "A headless e-commerce experience with personalized product curation, seamless checkout flows, and automated inventory sync across storefronts.",
+    image: {
+      src: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80",
+      alt: "Person browsing an online store on a tablet and phone.",
+    },
+    technologies: ["Next.js", "Shopify", "GraphQL"],
+    href: "https://example.com/aurora-commerce",
+    hrefLabel: "Visit project",
+  },
+  {
+    title: "Horizon Studio Portfolio",
+    description:
+      "A modular creative studio portfolio designed to showcase motion work with cinematic storytelling, parallax transitions, and accessible navigation controls.",
+    image: {
+      src: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&q=80",
+      alt: "Designers collaborating while viewing a web project on a laptop.",
+    },
+    technologies: ["Next.js", "Contentful", "Framer Motion"],
+    href: "https://example.com/horizon-studio",
+    hrefLabel: "See live site",
+  },
+];
+
+export default function ProjectsSection() {
+  return (
+    <section id="projects" className="bg-background py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            Featured Work
+          </p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Projects that blend thoughtful design with reliable engineering
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            From data-rich dashboards to immersive brand experiences, here are a few highlights from recent client collaborations.
+          </p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <Card
+              key={project.title}
+              className="group flex h-full flex-col overflow-hidden border-muted/60 transition hover:shadow-lg"
+            >
+              <div className="relative h-52 w-full overflow-hidden">
+                <Image
+                  src={project.image.src}
+                  alt={project.image.alt}
+                  fill
+                  sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                  className="object-cover transition duration-500 group-hover:scale-105"
+                  priority={false}
+                />
+              </div>
+
+              <div className="flex flex-1 flex-col gap-5 p-6">
+                <div className="space-y-3">
+                  <h3 className="text-xl font-semibold text-foreground">{project.title}</h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {project.description}
+                  </p>
+                </div>
+
+                <ul className="flex flex-wrap gap-2">
+                  {project.technologies.map((technology) => (
+                    <li
+                      key={technology}
+                      className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground"
+                    >
+                      {technology}
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-auto pt-2">
+                  <Button asChild className="w-full">
+                    <Link href={project.href} target="_blank" rel="noreferrer noopener">
+                      {project.hrefLabel}
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -64,10 +64,10 @@ export default function ProjectsSection() {
             Featured Work
           </p>
           <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            Projects that blend thoughtful design with reliable engineering
+            Crafted digital experiences grounded in strategic, scalable engineering
           </h2>
           <p className="mt-4 text-base text-muted-foreground">
-            From data-rich dashboards to immersive brand experiences, here are a few highlights from recent client collaborations.
+            Explore a selection of engagements where tailored design systems, performant architectures, and measurable outcomes came together to advance client goals.
           </p>
         </div>
 
@@ -75,7 +75,7 @@ export default function ProjectsSection() {
           {projects.map((project) => (
             <Card
               key={project.title}
-              className="flex h-full flex-col overflow-hidden border-muted/60 transition hover:shadow-lg"
+              className="flex h-full flex-col overflow-hidden border-muted/60"
             >
               <div className="relative h-52 w-full overflow-hidden">
                 <Image

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -75,7 +75,7 @@ export default function ProjectsSection() {
           {projects.map((project) => (
             <Card
               key={project.title}
-              className="group flex h-full flex-col overflow-hidden border-muted/60 transition hover:shadow-lg"
+              className="flex h-full flex-col overflow-hidden border-muted/60 transition hover:shadow-lg"
             >
               <div className="relative h-52 w-full overflow-hidden">
                 <Image
@@ -83,7 +83,7 @@ export default function ProjectsSection() {
                   alt={project.image.alt}
                   fill
                   sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-                  className="object-cover transition duration-500 group-hover:scale-105"
+                  className="object-cover transition duration-500 hover:scale-105"
                   priority={false}
                 />
               </div>


### PR DESCRIPTION
## Summary
- add a featured projects section with three representative projects, descriptions, and technology badges
- include the new projects section on the home page ahead of the contact form
- configure Next.js image settings to allow temporary Unsplash previews

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' due to missing dependencies)*
- `npm install` *(fails: npm registry returned 403 for @tiptap/react)*

------
https://chatgpt.com/codex/tasks/task_e_68d63ae42b4c8327b23dfa426865fe1a