### PR TITLE
Add contact section wrapper for contact form

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
-import ContactForm from "@/components/contact-form";
+import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
 
 export default function Home() {
   return (
     <main className="space-y-24">
       <ProjectsSection />
-      <ContactForm />
+      <ContactSection />
     </main>
   );
 }

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -1,0 +1,24 @@
+import ContactForm from "@/components/contact-form";
+
+export default function ContactSection() {
+  return (
+    <section id="contact" className="bg-muted/30 py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            Let’s Connect
+          </p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Partner with a developer focused on clarity, collaboration, and delivery
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            Ready to discuss a new initiative or enhance an existing product? Share a few details below and I’ll follow up with
+            thoughtful next steps tailored to your goals.
+          </p>
+        </div>
+
+        <ContactForm />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated contact section that mirrors the featured projects section styling and wraps the existing contact form
- update the home page layout to render the new contact section in place of the raw form component

## Testing
- npm run lint *(fails: missing dependency `@eslint/eslintrc` required by the existing config)*

------
https://chatgpt.com/codex/tasks/task_e_68ea432c9de08327aea01b9ecf177a66