### PR TITLE
Standardize card styling in project and contact sections

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -335,7 +335,7 @@ export default function ContactForm() {
             </div>
           </div>
         </CardContent>
-        <CardFooter className="flex-col items-stretch gap-2 border-t border-border/60 px-6 py-4 md:flex-row md:items-center md:justify-between">
+        <CardFooter className="flex-col items-stretch gap-2 px-6 md:flex-row md:items-center md:justify-between">
           <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
             {isSubmitting ? 'Sending…' : 'Send message'}
           </Button>

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -11,7 +11,7 @@ export default function ContactSection() {
             Get in touch
           </p>
           <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            Let&rsquo;s plan what&rsquo;s next for your team
+            Let&rsquo;s build something great together
           </h2>
           <p className="mt-4 text-base text-muted-foreground">
             Share your goals, timelines, and challenges. I&rsquo;ll reply within two business days to explore a meaningful partnership.
@@ -21,7 +21,6 @@ export default function ContactSection() {
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <Card className="mx-auto w-full max-w-xl self-start">
             <CardHeader className="space-y-3">
-              <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">Contact Details</p>
               <CardTitle className="text-xl text-foreground">Let&rsquo;s connect</CardTitle>
               <CardDescription className="text-sm leading-relaxed">
                 I&rsquo;m available to answer questions, explore opportunities, and discuss potential collaborations.

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -4,7 +4,7 @@ import { Mail, MapPin, Phone } from "lucide-react";
 
 export default function ContactSection() {
   return (
-    <section id="contact" className="bg-muted/20 py-16 lg:py-20">
+    <section id="contact" className="py-16 lg:py-20">
       <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
           <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -11,11 +11,10 @@ export default function ContactSection() {
             Get in touch
           </p>
           <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            Let&rsquo;s collaborate on what&rsquo;s next for your product or team
+            Let&rsquo;s plan what&rsquo;s next for your team
           </h2>
           <p className="mt-4 text-base text-muted-foreground">
-            Share a few details about your goals, timelines, and the challenges you&rsquo;re solving. I&rsquo;ll respond within
-            two business days to explore how we can create an impactful partnership.
+            Share your goals, timelines, and challenges. I&rsquo;ll reply within two business days to explore a meaningful partnership.
           </p>
         </div>
 

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -20,7 +20,7 @@ export default function ContactSection() {
         </div>
 
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <Card className="mx-auto w-full max-w-xl">
+          <Card className="mx-auto w-full max-w-xl self-start">
             <CardHeader className="space-y-3">
               <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">Contact Details</p>
               <CardTitle className="text-xl text-foreground">Let&rsquo;s connect</CardTitle>

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -20,10 +20,10 @@ export default function ContactSection() {
         </div>
 
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <Card className="mx-auto w-full max-w-xl border-muted/60 bg-card/95 backdrop-blur">
+          <Card className="mx-auto w-full max-w-xl">
             <CardHeader className="space-y-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">Contact Details</p>
-              <CardTitle className="text-2xl font-semibold tracking-tight text-foreground">Let&rsquo;s connect</CardTitle>
+              <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">Contact Details</p>
+              <CardTitle className="text-xl text-foreground">Let&rsquo;s connect</CardTitle>
               <CardDescription className="text-sm leading-relaxed">
                 I&rsquo;m available to answer questions, explore opportunities, and discuss potential collaborations.
               </CardDescription>
@@ -35,7 +35,7 @@ export default function ContactSection() {
                     <Phone className="h-5 w-5" aria-hidden />
                   </div>
                   <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                    <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
                       Phone
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">+63 977 333 6944</dd>
@@ -47,7 +47,7 @@ export default function ContactSection() {
                     <Mail className="h-5 w-5" aria-hidden />
                   </div>
                   <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                    <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
                       Email
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">
@@ -63,7 +63,7 @@ export default function ContactSection() {
                     <MapPin className="h-5 w-5" aria-hidden />
                   </div>
                   <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                    <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
                       Location
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">Mabalacat, Pampanga, Philippines</dd>

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -49,8 +49,8 @@ export default function ContactSection() {
                       Email
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">
-                      <a className="hover:text-primary" href="mailto:artcherolemernaldo@gmail.com">
-                        artcherolemernaldo@gmail.com
+                      <a className="hover:text-primary" href="mailto:antholemlemmanalo@gmail.com">
+                        antholemlemmanalo@gmail.com
                       </a>
                     </dd>
                   </div>

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -51,7 +51,7 @@ export default function ContactSection() {
                       Email
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">
-                      <a className="transition-colors hover:text-primary" href="mailto:artcherolemernaldo@gmail.com">
+                      <a className="hover:text-primary" href="mailto:artcherolemernaldo@gmail.com">
                         artcherolemernaldo@gmail.com
                       </a>
                     </dd>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -2,7 +2,13 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 type Project = {
   title: string;
@@ -73,10 +79,7 @@ export default function ProjectsSection() {
 
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
           {projects.map((project) => (
-            <Card
-              key={project.title}
-              className="flex h-full flex-col overflow-hidden border-muted/60"
-            >
+            <Card key={project.title} className="flex h-full flex-col overflow-hidden">
               <div className="relative h-52 w-full overflow-hidden">
                 <Image
                   src={project.image.src}
@@ -88,14 +91,14 @@ export default function ProjectsSection() {
                 />
               </div>
 
-              <div className="flex flex-1 flex-col gap-5 p-6">
-                <div className="space-y-3">
-                  <h3 className="text-xl font-semibold text-foreground">{project.title}</h3>
-                  <p className="text-sm leading-relaxed text-muted-foreground">
-                    {project.description}
-                  </p>
-                </div>
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-xl text-foreground">{project.title}</CardTitle>
+                <CardDescription className="text-sm leading-relaxed">
+                  {project.description}
+                </CardDescription>
+              </CardHeader>
 
+              <CardContent className="flex flex-1 flex-col gap-5">
                 <ul className="flex flex-wrap gap-2">
                   {project.technologies.map((technology) => (
                     <li
@@ -107,14 +110,14 @@ export default function ProjectsSection() {
                   ))}
                 </ul>
 
-                <div className="mt-auto pt-2">
+                <div className="mt-auto">
                   <Button asChild className="w-full">
                     <Link href={project.href} target="_blank" rel="noreferrer noopener">
                       {project.hrefLabel}
                     </Link>
                   </Button>
                 </div>
-              </div>
+              </CardContent>
             </Card>
           ))}
         </div>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -70,10 +70,10 @@ export default function ProjectsSection() {
             Featured Work
           </p>
           <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-            Crafted digital experiences grounded in strategic, scalable engineering
+            Digital experiences built for scalable impact
           </h2>
           <p className="mt-4 text-base text-muted-foreground">
-            Explore a selection of engagements where tailored design systems, performant architectures, and measurable outcomes came together to advance client goals.
+            Explore engagements that pair thoughtful design, performant systems, and measurable outcomes to advance client goals.
           </p>
         </div>
 

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -81,14 +81,14 @@ export default function ProjectsSection() {
           {projects.map((project) => (
             <Card key={project.title} className="flex h-full flex-col overflow-hidden">
               <div className="relative h-52 w-full overflow-hidden">
-                {/* <Image
+                <Image
                   src={project.image.src}
                   alt={project.image.alt}
                   fill
                   sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                   className="object-cover transition duration-500 hover:scale-105"
                   priority={false}
-                /> */}
+                />
               </div>
 
               <CardHeader className="space-y-3">

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -81,14 +81,14 @@ export default function ProjectsSection() {
           {projects.map((project) => (
             <Card key={project.title} className="flex h-full flex-col overflow-hidden">
               <div className="relative h-52 w-full overflow-hidden">
-                <Image
+                {/* <Image
                   src={project.image.src}
                   alt={project.image.alt}
                   fill
                   sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                   className="object-cover transition duration-500 hover:scale-105"
                   priority={false}
-                />
+                /> */}
               </div>
 
               <CardHeader className="space-y-3">


### PR DESCRIPTION
## Summary
- update project cards to use the shared CardHeader, CardContent, and typography defaults for a cleaner layout
- align the contact card with the default card styling and adjust typography for consistency with the projects section

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68ea79ade314832781c925a71a5ecca4