### PR TITLE
Simplify styling of project and contact cards

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -7,7 +7,7 @@ export default function ContactSection() {
     <section id="contact" className="bg-muted/20 py-16 lg:py-20">
       <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/80">
             Get in touch
           </p>
           <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
@@ -20,22 +20,22 @@ export default function ContactSection() {
         </div>
 
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <Card className="mx-auto w-full max-w-xl border-muted/60 bg-card/95 backdrop-blur">
-            <CardHeader className="space-y-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">Contact Details</p>
+          <Card className="mx-auto w-full max-w-xl">
+            <CardHeader className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/70">Contact Details</p>
               <CardTitle className="text-2xl font-semibold tracking-tight text-foreground">Let&rsquo;s connect</CardTitle>
-              <CardDescription className="text-sm leading-relaxed">
+              <CardDescription className="leading-relaxed">
                 I&rsquo;m available to answer questions, explore opportunities, and discuss potential collaborations.
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-5">
-              <dl className="space-y-5 text-left">
+            <CardContent className="space-y-6">
+              <dl className="space-y-6 text-left">
                 <div className="flex items-start gap-4">
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
                     <Phone className="h-5 w-5" aria-hidden />
                   </div>
                   <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                    <dt className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground/80">
                       Phone
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">+63 977 333 6944</dd>
@@ -47,7 +47,7 @@ export default function ContactSection() {
                     <Mail className="h-5 w-5" aria-hidden />
                   </div>
                   <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                    <dt className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground/80">
                       Email
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">
@@ -63,7 +63,7 @@ export default function ContactSection() {
                     <MapPin className="h-5 w-5" aria-hidden />
                   </div>
                   <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                    <dt className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground/80">
                       Location
                     </dt>
                     <dd className="mt-1 text-base font-medium text-foreground">Mabalacat, Pampanga, Philippines</dd>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
 
 type Project = {
   title: string;
@@ -60,7 +60,7 @@ export default function ProjectsSection() {
     <section id="projects" className="bg-background py-16 lg:py-20">
       <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary/80">
             Featured Work
           </p>
           <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
@@ -75,7 +75,7 @@ export default function ProjectsSection() {
           {projects.map((project) => (
             <Card
               key={project.title}
-              className="flex h-full flex-col overflow-hidden border-muted/60"
+              className="flex h-full flex-col overflow-hidden"
             >
               <div className="relative h-52 w-full overflow-hidden">
                 <Image
@@ -88,12 +88,10 @@ export default function ProjectsSection() {
                 />
               </div>
 
-              <div className="flex flex-1 flex-col gap-5 p-6">
-                <div className="space-y-3">
+              <CardContent className="flex flex-1 flex-col gap-6 pt-6">
+                <div className="space-y-2">
                   <h3 className="text-xl font-semibold text-foreground">{project.title}</h3>
-                  <p className="text-sm leading-relaxed text-muted-foreground">
-                    {project.description}
-                  </p>
+                  <p className="text-sm leading-relaxed text-muted-foreground">{project.description}</p>
                 </div>
 
                 <ul className="flex flex-wrap gap-2">
@@ -106,15 +104,14 @@ export default function ProjectsSection() {
                     </li>
                   ))}
                 </ul>
-
-                <div className="mt-auto pt-2">
-                  <Button asChild className="w-full">
-                    <Link href={project.href} target="_blank" rel="noreferrer noopener">
-                      {project.hrefLabel}
-                    </Link>
-                  </Button>
-                </div>
-              </div>
+              </CardContent>
+              <CardFooter className="mt-auto w-full">
+                <Button asChild className="w-full">
+                  <Link href={project.href} target="_blank" rel="noreferrer noopener">
+                    {project.hrefLabel}
+                  </Link>
+                </Button>
+              </CardFooter>
             </Card>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- align the project and contact section headings and supporting copy for consistent typography
- remove custom card border and backdrop styles so both sections use the default Card appearance
- restructure project cards to rely on CardContent and CardFooter for cleaner layout around the call-to-action

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68ea79ade314832781c925a71a5ecca4