### PR TITLE
Refine project and contact cards

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -20,16 +20,16 @@ export default function ContactSection() {
         </div>
 
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <Card className="mx-auto w-full max-w-xl border-muted/60 bg-card/95 backdrop-blur">
-            <CardHeader className="space-y-3">
+          <Card className="mx-auto w-full max-w-xl">
+            <CardHeader className="space-y-2">
               <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">Contact Details</p>
-              <CardTitle className="text-2xl font-semibold tracking-tight text-foreground">Let&rsquo;s connect</CardTitle>
-              <CardDescription className="text-sm leading-relaxed">
+              <CardTitle>Let&rsquo;s connect</CardTitle>
+              <CardDescription className="leading-relaxed">
                 I&rsquo;m available to answer questions, explore opportunities, and discuss potential collaborations.
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-5">
-              <dl className="space-y-5 text-left">
+            <CardContent className="space-y-6">
+              <dl className="space-y-6 text-left">
                 <div className="flex items-start gap-4">
                   <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
                     <Phone className="h-5 w-5" aria-hidden />

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -2,7 +2,14 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 type Project = {
   title: string;
@@ -73,11 +80,8 @@ export default function ProjectsSection() {
 
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
           {projects.map((project) => (
-            <Card
-              key={project.title}
-              className="flex h-full flex-col overflow-hidden border-muted/60"
-            >
-              <div className="relative h-52 w-full overflow-hidden">
+            <Card key={project.title} className="flex h-full flex-col overflow-hidden">
+              <div className="relative aspect-[4/3] w-full overflow-hidden">
                 <Image
                   src={project.image.src}
                   alt={project.image.alt}
@@ -88,15 +92,15 @@ export default function ProjectsSection() {
                 />
               </div>
 
-              <div className="flex flex-1 flex-col gap-5 p-6">
-                <div className="space-y-3">
-                  <h3 className="text-xl font-semibold text-foreground">{project.title}</h3>
-                  <p className="text-sm leading-relaxed text-muted-foreground">
-                    {project.description}
-                  </p>
-                </div>
+              <CardHeader className="flex flex-1 flex-col space-y-3">
+                <CardTitle>{project.title}</CardTitle>
+                <CardDescription className="leading-relaxed">
+                  {project.description}
+                </CardDescription>
+              </CardHeader>
 
-                <ul className="flex flex-wrap gap-2">
+              <CardContent className="pt-0">
+                <ul className="flex flex-wrap gap-2 text-sm">
                   {project.technologies.map((technology) => (
                     <li
                       key={technology}
@@ -106,15 +110,15 @@ export default function ProjectsSection() {
                     </li>
                   ))}
                 </ul>
+              </CardContent>
 
-                <div className="mt-auto pt-2">
-                  <Button asChild className="w-full">
-                    <Link href={project.href} target="_blank" rel="noreferrer noopener">
-                      {project.hrefLabel}
-                    </Link>
-                  </Button>
-                </div>
-              </div>
+              <CardFooter className="pt-0">
+                <Button asChild className="w-full">
+                  <Link href={project.href} target="_blank" rel="noreferrer noopener">
+                    {project.hrefLabel}
+                  </Link>
+                </Button>
+              </CardFooter>
             </Card>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- restructure project cards to use shared Card subcomponents for consistent layout
- simplify the contact details card styling to rely on the default Card appearance
- align typography across the project and contact sections for a cleaner presentation

## Testing
- npm run lint *(fails: missing @eslint/eslintrc because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea79ade314832781c925a71a5ecca4