### PR TITLE
Refine card styling in projects and contact sections

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -2,6 +2,26 @@ import ContactForm from "@/components/contact-form";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Mail, MapPin, Phone } from "lucide-react";
 
+const contactDetails = [
+  {
+    icon: Phone,
+    label: "Phone",
+    value: "+63 977 333 6944",
+    href: "tel:+639773336944",
+  },
+  {
+    icon: Mail,
+    label: "Email",
+    value: "artcherolemernaldo@gmail.com",
+    href: "mailto:artcherolemernaldo@gmail.com",
+  },
+  {
+    icon: MapPin,
+    label: "Location",
+    value: "Mabalacat, Pampanga, Philippines",
+  },
+];
+
 export default function ContactSection() {
   return (
     <section id="contact" className="bg-muted/20 py-16 lg:py-20">
@@ -20,55 +40,37 @@ export default function ContactSection() {
         </div>
 
         <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <Card className="mx-auto w-full max-w-xl border-muted/60 bg-card/95 backdrop-blur">
-            <CardHeader className="space-y-3">
+          <Card className="mx-auto w-full max-w-xl">
+            <CardHeader className="space-y-4">
               <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">Contact Details</p>
               <CardTitle className="text-2xl font-semibold tracking-tight text-foreground">Let&rsquo;s connect</CardTitle>
-              <CardDescription className="text-sm leading-relaxed">
+              <CardDescription className="leading-relaxed">
                 I&rsquo;m available to answer questions, explore opportunities, and discuss potential collaborations.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-5">
               <dl className="space-y-5 text-left">
-                <div className="flex items-start gap-4">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-                    <Phone className="h-5 w-5" aria-hidden />
+                {contactDetails.map(({ icon: Icon, label, value, href }) => (
+                  <div key={label} className="flex items-start gap-4">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                      <Icon className="h-5 w-5" aria-hidden />
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
+                        {label}
+                      </dt>
+                      <dd className="mt-1 text-base font-medium text-foreground">
+                        {href ? (
+                          <a className="transition-colors hover:text-primary" href={href}>
+                            {value}
+                          </a>
+                        ) : (
+                          value
+                        )}
+                      </dd>
+                    </div>
                   </div>
-                  <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
-                      Phone
-                    </dt>
-                    <dd className="mt-1 text-base font-medium text-foreground">+63 977 333 6944</dd>
-                  </div>
-                </div>
-
-                <div className="flex items-start gap-4">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-                    <Mail className="h-5 w-5" aria-hidden />
-                  </div>
-                  <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
-                      Email
-                    </dt>
-                    <dd className="mt-1 text-base font-medium text-foreground">
-                      <a className="transition-colors hover:text-primary" href="mailto:artcherolemernaldo@gmail.com">
-                        artcherolemernaldo@gmail.com
-                      </a>
-                    </dd>
-                  </div>
-                </div>
-
-                <div className="flex items-start gap-4">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-                    <MapPin className="h-5 w-5" aria-hidden />
-                  </div>
-                  <div>
-                    <dt className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground/80">
-                      Location
-                    </dt>
-                    <dd className="mt-1 text-base font-medium text-foreground">Mabalacat, Pampanga, Philippines</dd>
-                  </div>
-                </div>
+                ))}
               </dl>
             </CardContent>
           </Card>

--- a/src/components/projects-section.tsx
+++ b/src/components/projects-section.tsx
@@ -2,7 +2,14 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 type Project = {
   title: string;
@@ -73,10 +80,7 @@ export default function ProjectsSection() {
 
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
           {projects.map((project) => (
-            <Card
-              key={project.title}
-              className="flex h-full flex-col overflow-hidden border-muted/60"
-            >
+            <Card key={project.title} className="flex h-full flex-col overflow-hidden">
               <div className="relative h-52 w-full overflow-hidden">
                 <Image
                   src={project.image.src}
@@ -88,14 +92,15 @@ export default function ProjectsSection() {
                 />
               </div>
 
-              <div className="flex flex-1 flex-col gap-5 p-6">
-                <div className="space-y-3">
-                  <h3 className="text-xl font-semibold text-foreground">{project.title}</h3>
-                  <p className="text-sm leading-relaxed text-muted-foreground">
-                    {project.description}
-                  </p>
-                </div>
-
+              <CardHeader className="space-y-4">
+                <CardTitle className="text-xl font-semibold text-foreground">
+                  {project.title}
+                </CardTitle>
+                <CardDescription className="text-sm leading-relaxed">
+                  {project.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col gap-5">
                 <ul className="flex flex-wrap gap-2">
                   {project.technologies.map((technology) => (
                     <li
@@ -106,15 +111,14 @@ export default function ProjectsSection() {
                     </li>
                   ))}
                 </ul>
-
-                <div className="mt-auto pt-2">
-                  <Button asChild className="w-full">
-                    <Link href={project.href} target="_blank" rel="noreferrer noopener">
-                      {project.hrefLabel}
-                    </Link>
-                  </Button>
-                </div>
-              </div>
+              </CardContent>
+              <CardFooter>
+                <Button asChild className="w-full">
+                  <Link href={project.href} target="_blank" rel="noreferrer noopener">
+                    {project.hrefLabel}
+                  </Link>
+                </Button>
+              </CardFooter>
             </Card>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- align the project cards with the default card appearance and internal structure for consistent typography and layout
- simplify the contact details card, reusing shared data while keeping the default card styling for a cleaner presentation

## Testing
- `npm run lint` *(fails: missing dependency `@eslint/eslintrc`)*

------
https://chatgpt.com/codex/tasks/task_e_68ea79ade314832781c925a71a5ecca4