### PR TITLE
Add skills section to portfolio home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
+import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
     <main className="space-y-2">
       <ProjectsSection />
+      <SkillsSection />
       <ContactSection />
     </main>
   );

--- a/src/components/skills-section.tsx
+++ b/src/components/skills-section.tsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const skillCategories = [
+  {
+    title: "Frontend Engineering",
+    description:
+      "Type-safe interfaces crafted with accessible components, design systems, and responsive interaction patterns.",
+    skills: ["Next.js", "React", "TypeScript", "Tailwind CSS", "Radix UI"],
+  },
+  {
+    title: "Backend & APIs",
+    description:
+      "Resilient services with efficient data workflows, secure integrations, and predictable contract-first APIs.",
+    skills: ["Node.js", "tRPC", "REST", "GraphQL", "Prisma"],
+  },
+  {
+    title: "DevOps & Tooling",
+    description:
+      "Automation pipelines and observability practices that keep delivery fast, dependable, and insight-driven.",
+    skills: ["Vercel", "Docker", "GitHub Actions", "Playwright", "Storybook"],
+  },
+  {
+    title: "Product Strategy",
+    description:
+      "Collaborative discovery, roadmap alignment, and measurement plans that connect user value to business outcomes.",
+    skills: ["Roadmapping", "Experimentation", "Analytics", "Stakeholder Workshops", "UX Research"],
+  },
+] as const;
+
+export default function SkillsSection() {
+  return (
+    <section id="skills" className="py-16 lg:py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">Core capabilities</p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Skills that move products from concept to launch
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            A balanced toolkit across design systems, platform architecture, and delivery rituals to keep cross-functional teams
+            aligned and shipping.
+          </p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {skillCategories.map((category) => (
+            <Card key={category.title} className="flex h-full flex-col">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-xl text-foreground">{category.title}</CardTitle>
+                <CardDescription className="text-sm leading-relaxed">
+                  {category.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <ul className="flex flex-wrap gap-2">
+                  {category.skills.map((skill) => (
+                    <li
+                      key={skill}
+                      className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground"
+                    >
+                      {skill}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated skills section that mirrors the headline and description patterns used elsewhere on the page
- present four core capability areas with supporting descriptions and skill badges inside cards
- insert the new skills section between the projects and contact sections on the home page

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea89f728508327a6a1d628c4091524