### PR TITLE
Add structured skills section to home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
+import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
-    <main className="space-y-2">
+    <main className="space-y-16">
+      <SkillsSection />
       <ProjectsSection />
       <ContactSection />
     </main>

--- a/src/components/skills-section.tsx
+++ b/src/components/skills-section.tsx
@@ -1,0 +1,78 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const skillCategories = [
+  {
+    title: "Frontend foundations",
+    description: "Crafting accessible interfaces with modern web standards and resilient layouts.",
+    skills: ["HTML5", "CSS3", "Responsive Design", "Accessibility"],
+  },
+  {
+    title: "Application frameworks",
+    description: "Building interactive views and performant user journeys with component-driven systems.",
+    skills: ["React", "Next.js", "Redux Toolkit", "Framer Motion"],
+  },
+  {
+    title: "Tooling & quality",
+    description: "Ensuring maintainable codebases through reliable tooling, testing, and automation.",
+    skills: ["TypeScript", "Jest", "Playwright", "ESLint"],
+  },
+  {
+    title: "Styling systems",
+    description: "Designing cohesive visual languages with scalable design tokens and utilities.",
+    skills: ["Tailwind CSS", "Styled Components", "Radix UI", "Design Systems"],
+  },
+  {
+    title: "Backend & APIs",
+    description: "Connecting experiences to robust services with modern API and data layers.",
+    skills: ["Node.js", "REST", "GraphQL", "Prisma"],
+  },
+  {
+    title: "Collaboration",
+    description: "Shipping features efficiently within cross-functional teams and workflows.",
+    skills: ["Agile Delivery", "Storybook", "Figma", "Git & GitHub"],
+  },
+] as const;
+
+export default function SkillsSection() {
+  return (
+    <section id="skills" className="bg-muted/40 py-16 lg:py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">Core capabilities</p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Skills that bring ideas from concept to launch
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            From initial discovery to production-ready delivery, these are the tools and practices I rely on to build fast,
+            inclusive digital experiences.
+          </p>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          {skillCategories.map((category) => (
+            <Card key={category.title} className="h-full border-border/60">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-lg text-foreground">{category.title}</CardTitle>
+                <CardDescription className="text-sm leading-relaxed">
+                  {category.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="flex flex-wrap gap-2">
+                  {category.skills.map((skill) => (
+                    <li
+                      key={skill}
+                      className="rounded-full bg-secondary/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-secondary-foreground"
+                    >
+                      {skill}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated skills section that highlights core capabilities and supporting tools
- update the home page layout to include the new skills section and provide generous spacing between sections

## Testing
- not run (npm install fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/@tiptap%2freact)


------
https://chatgpt.com/codex/tasks/task_e_68eb00ecfe088327a2cfd7717be90047