### PR TITLE
Add skills section to portfolio homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
+import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
     <main className="space-y-2">
       <ProjectsSection />
+      <SkillsSection />
       <ContactSection />
     </main>
   );

--- a/src/components/skills-section.tsx
+++ b/src/components/skills-section.tsx
@@ -1,0 +1,67 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const skills = [
+  {
+    title: "Frontend Craft",
+    description:
+      "Interfaces engineered with clean architecture, delightful animations, and resilient accessibility foundations.",
+    items: ["HTML5", "CSS3", "TypeScript", "React", "Next.js", "Tailwind CSS"],
+  },
+  {
+    title: "Systems & Tooling",
+    description:
+      "Modern tooling that keeps delivery fast, observable, and production ready across environments.",
+    items: ["Node.js", "REST APIs", "GraphQL", "Vite", "Jest", "Playwright"],
+  },
+  {
+    title: "Collaboration",
+    description:
+      "Processes that align cross-functional teams and keep product momentum moving forward.",
+    items: ["Agile Coaching", "Design Systems", "UX Collaboration", "CI/CD", "Storybook", "Notion"],
+  },
+];
+
+export default function SkillsSection() {
+  return (
+    <section id="skills" className="bg-muted/40 py-16 lg:py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            Core capabilities
+          </p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Skills that deliver end-to-end product outcomes
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            A blend of engineering depth and product collaboration to ship experiences users love and teams can maintain.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {skills.map((skill) => (
+            <Card key={skill.title} className="border-border/60 bg-background shadow-sm">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-xl text-foreground">{skill.title}</CardTitle>
+                <CardDescription className="text-sm leading-relaxed text-muted-foreground">
+                  {skill.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="flex flex-wrap gap-2">
+                  {skill.items.map((item) => (
+                    <li
+                      key={item}
+                      className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground"
+                    >
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated skills section highlighting core capabilities with badges
- surface the new skills section on the homepage between projects and contact

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb00ecfe088327a2cfd7717be90047