### PR TITLE
Add dedicated skills section to home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
+import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
     <main className="space-y-2">
       <ProjectsSection />
+      <SkillsSection />
       <ContactSection />
     </main>
   );

--- a/src/components/skills-section.tsx
+++ b/src/components/skills-section.tsx
@@ -1,0 +1,82 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const skillCategories = [
+  {
+    title: "Front-end Engineering",
+    description:
+      "Crafting polished interfaces with performance-minded frameworks, component systems, and modern styling tooling.",
+    skills: ["ReactJS", "NextJS", "Tailwind CSS", "Chakra UI", "Material UI", "Shadcn"],
+  },
+  {
+    title: "Backend & APIs",
+    description:
+      "Designing resilient services, APIs, and integrations that scale reliably across diverse runtime environments.",
+    skills: ["Backend", "NodeJS", "ExpressJS", "PHP", "Python", "Java"],
+  },
+  {
+    title: "Data & Cloud Platforms",
+    description:
+      "Implementing data models and real-time experiences backed by managed services and developer-friendly platforms.",
+    skills: ["MongoDB", "MySQL", "PostgreSQL", "Firebase", "Supabase"],
+  },
+  {
+    title: "DevOps & Delivery",
+    description:
+      "Automating delivery workflows and observability to ship confidently from local development to production.",
+    skills: ["Docker", "Vercel", "GitHub", "GitLab"],
+  },
+  {
+    title: "Design & Collaboration",
+    description:
+      "Translating ideas into intuitive journeys through iterative prototyping, feedback loops, and design systems.",
+    skills: ["Figma", "Adobe XD"],
+  },
+  {
+    title: "AI & Emerging Tech",
+    description:
+      "Exploring intelligent tooling to accelerate product discovery, experimentation, and personalized experiences.",
+    skills: ["Hugging Face", "Google Gemini"],
+  },
+] as const;
+
+export default function SkillsSection() {
+  return (
+    <section id="skills" className="bg-muted/30 py-16 lg:py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">Core capabilities</p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            A full-stack toolkit for shipping production-ready products
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            From interface architecture to deployment pipelines, I bring a balanced skill set to deliver resilient, maintainable,
+            and human-centered software solutions.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {skillCategories.map((category) => (
+            <Card key={category.title} className="flex h-full flex-col">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-lg text-foreground">{category.title}</CardTitle>
+                <CardDescription className="text-sm leading-relaxed">{category.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <ul className="flex flex-wrap gap-2">
+                  {category.skills.map((skill) => (
+                    <li
+                      key={skill}
+                      className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground"
+                    >
+                      {skill}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable skills section component that organizes provided skills into themed categories
- surface the new section on the landing page between the projects and contact areas for consistent storytelling

## Testing
- npm run lint *(fails: missing dependency `@eslint/eslintrc` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0970b31c8327804fae43c7a163c3