### PR TITLE
Add services section and update navigation labels

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
+import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
     <main className="space-y-2">
       <ProjectsSection />
+      <ServicesSection />
       <SkillsSection />
       <ContactSection />
     </main>

--- a/src/components/services-section.tsx
+++ b/src/components/services-section.tsx
@@ -1,0 +1,90 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const services = [
+  {
+    title: "Product Strategy & Discovery",
+    description:
+      "Align business goals with user needs through structured research, roadmapping, and measurable success criteria.",
+    highlights: [
+      "Stakeholder workshops",
+      "User journey mapping",
+      "Lean validation sprints",
+    ],
+  },
+  {
+    title: "Experience & Interface Design",
+    description:
+      "Design intuitive, inclusive interfaces backed by reusable component systems and purposeful visual direction.",
+    highlights: [
+      "Design systems & UI kits",
+      "Interactive prototyping",
+      "Accessibility reviews",
+    ],
+  },
+  {
+    title: "Full-Stack Engineering",
+    description:
+      "Ship performant applications with maintainable architectures, API integrations, and reliable deployment workflows.",
+    highlights: [
+      "Next.js & modern front-end",
+      "API & data layer development",
+      "CI/CD automation",
+    ],
+  },
+  {
+    title: "Lifecycle Partnership",
+    description:
+      "Support releases post-launch with analytics, experiments, and iteration to keep teams moving confidently.",
+    highlights: [
+      "Launch planning & QA",
+      "Observability dashboards",
+      "Growth experiments",
+    ],
+  },
+] as const;
+
+export default function ServicesSection() {
+  return (
+    <section id="services" className="bg-muted/40 py-16 lg:py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            Services
+          </p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Partnering end-to-end to move ideas into real impact
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            From first insight to post-launch iteration, I help teams design, build, and evolve digital products with clarity and
+            measurable outcomes.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {services.map((service) => (
+            <Card key={service.title} className="flex h-full flex-col">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-lg text-foreground">{service.title}</CardTitle>
+                <CardDescription className="text-sm leading-relaxed">
+                  {service.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <ul className="flex flex-wrap gap-2">
+                  {service.highlights.map((highlight) => (
+                    <li
+                      key={highlight}
+                      className="rounded-full bg-secondary px-3 py-1 text-xs font-medium text-secondary-foreground"
+                    >
+                      {highlight}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -18,10 +18,10 @@ import { Separator } from "@/components/ui/separator"
 
 const links = [
     { href: "/", label: "About" },
-    { href: "#features", label: "Features" },
+    { href: "#services", label: "Services" },
     { href: "#skills", label: "Skills" },
     { href: "#projects", label: "Projects" },
-    { href: "#contacts", label: "Contacts" },
+    { href: "#contact", label: "Contact" },
 ]
 
 export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dark" }) {


### PR DESCRIPTION
## Summary
- replace the navbar Features link with a Services link and align the Contact anchor
- add a dedicated Services section outlining key offerings
- include the Services section on the home page between Projects and Skills

## Testing
- npm run lint *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68ef32a40ef4832792dbdb20c025166e