### PR TITLE
Add services section to portfolio navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
+import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
     <main className="space-y-2">
+      <ServicesSection />
       <ProjectsSection />
       <SkillsSection />
       <ContactSection />

--- a/src/components/services-section.tsx
+++ b/src/components/services-section.tsx
@@ -1,0 +1,104 @@
+import type { LucideIcon } from "lucide-react";
+import { Brain, Compass, LayoutDashboard, Server } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const services: {
+  title: string;
+  description: string;
+  highlights: string[];
+  icon: LucideIcon;
+}[] = [
+  {
+    title: "Product Discovery & Strategy",
+    description:
+      "Collaborative strategy sprints that align product vision, define success metrics, and prioritize the initiatives that deliver real value.",
+    highlights: [
+      "Product audits & opportunity mapping",
+      "Goal-driven roadmap facilitation",
+      "Experience blueprints & customer journeys",
+    ],
+    icon: Compass,
+  },
+  {
+    title: "Design Systems & Experience Design",
+    description:
+      "Modular, accessible interface systems that scale across platforms while preserving craft, clarity, and consistency.",
+    highlights: [
+      "Component libraries & documentation",
+      "Responsive UX patterns & prototyping",
+      "Accessibility-first interface audits",
+    ],
+    icon: LayoutDashboard,
+  },
+  {
+    title: "Full-stack Web Engineering",
+    description:
+      "Robust front-end and backend solutions that balance developer velocity with resilient architecture and observability.",
+    highlights: [
+      "Next.js and React application development",
+      "API design, integrations, and automation",
+      "Performance tuning & reliability engineering",
+    ],
+    icon: Server,
+  },
+  {
+    title: "AI-assisted Product Enablement",
+    description:
+      "Integrating intelligent tooling, workflows, and copilots that accelerate decision-making and augment human creativity.",
+    highlights: [
+      "Workflow automation & AI copilots",
+      "Knowledge base and content generation",
+      "Ethical AI implementation guidance",
+    ],
+    icon: Brain,
+  },
+];
+
+export default function ServicesSection() {
+  return (
+    <section id="services" className="bg-muted/40 py-16 lg:py-20">
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            Services
+          </p>
+          <h2 className="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Partnerships tailored to every stage of product growth
+          </h2>
+          <p className="mt-4 text-base text-muted-foreground">
+            From validating ideas to scaling platforms, I bring a multidisciplinary toolkit to plan, build, and evolve digital experiences that resonate.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {services.map((service) => (
+            <Card key={service.title} className="flex h-full flex-col">
+              <CardHeader className="space-y-4">
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <service.icon className="h-5 w-5" aria-hidden />
+                </span>
+                <div className="space-y-2">
+                  <CardTitle className="text-lg text-foreground">{service.title}</CardTitle>
+                  <CardDescription className="text-sm leading-relaxed">
+                    {service.description}
+                  </CardDescription>
+                </div>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <ul className="space-y-3 text-left">
+                  {service.highlights.map((highlight) => (
+                    <li key={highlight} className="flex items-start gap-2 text-sm text-muted-foreground">
+                      <span className="mt-1 inline-block size-1.5 flex-shrink-0 rounded-full bg-primary" aria-hidden />
+                      <span>{highlight}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/services-section.tsx
+++ b/src/components/services-section.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { Brain, Compass, LayoutDashboard, Server } from "lucide-react";
+import { Brain, LayoutDashboard, Server } from "lucide-react";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -9,17 +9,6 @@ const services: {
   highlights: string[];
   icon: LucideIcon;
 }[] = [
-  {
-    title: "Product Discovery & Strategy",
-    description:
-      "Collaborative strategy sprints that align product vision, define success metrics, and prioritize the initiatives that deliver real value.",
-    highlights: [
-      "Product audits & opportunity mapping",
-      "Goal-driven roadmap facilitation",
-      "Experience blueprints & customer journeys",
-    ],
-    icon: Compass,
-  },
   {
     title: "Design Systems & Experience Design",
     description:
@@ -71,7 +60,7 @@ export default function ServicesSection() {
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-6 md:grid-cols-3">
           {services.map((service) => (
             <Card key={service.title} className="flex h-full flex-col">
               <CardHeader className="space-y-4">

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -18,7 +18,7 @@ import { Separator } from "@/components/ui/separator"
 
 const links = [
     { href: "/", label: "About" },
-    { href: "#features", label: "Features" },
+    { href: "#services", label: "Services" },
     { href: "#skills", label: "Skills" },
     { href: "#projects", label: "Projects" },
     { href: "#contacts", label: "Contacts" },


### PR DESCRIPTION
## Summary
- rename the navigation link from Features to Services and point it at the new anchor
- introduce a Services section with icon cards that outline core offerings
- include the Services section in the homepage layout alongside existing sections

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ef32a40ef4832792dbdb20c025166e