### PR TITLE
Add hero section with professional profile presentation

### DIFF
--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,30 @@
+<svg width="640" height="800" viewBox="0 0 640 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E40AF" />
+      <stop offset="50%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#38BDF8" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="10%" r="70%">
+      <stop offset="0%" stop-color="rgba(148, 163, 184, 0.6)" />
+      <stop offset="40%" stop-color="rgba(148, 163, 184, 0.15)" />
+      <stop offset="100%" stop-color="rgba(15, 23, 42, 0.05)" />
+    </radialGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="24" stdDeviation="28" flood-color="#1E293B" flood-opacity="0.35" />
+    </filter>
+  </defs>
+  <rect width="640" height="800" rx="96" fill="#020817" />
+  <rect x="36" y="36" width="568" height="728" rx="80" fill="url(#glow)" />
+  <g filter="url(#shadow)">
+    <rect x="120" y="128" width="400" height="520" rx="72" fill="#0F172A" stroke="rgba(148, 163, 184, 0.25)" stroke-width="3" />
+    <path d="M320 236C350.928 236 376 211.376 376 180C376 148.624 350.928 124 320 124C289.072 124 264 148.624 264 180C264 211.376 289.072 236 320 236Z" fill="url(#gradient)" />
+    <path d="M320 268C248.924 268 192 324.924 192 396V408C192 418.247 200.253 426.5 210.5 426.5H429.5C439.747 426.5 448 418.247 448 408V396C448 324.924 391.076 268 320 268Z" fill="url(#gradient)" />
+    <rect x="208" y="440" width="224" height="160" rx="56" fill="#1E293B" />
+    <path d="M320 456C267.889 456 216 489.125 216 540C216 552.15 225.85 562 238 562H402C414.15 562 424 552.15 424 540C424 489.125 372.111 456 320 456Z" fill="#111827" />
+  </g>
+  <circle cx="520" cy="132" r="32" fill="rgba(56, 189, 248, 0.35)" />
+  <circle cx="112" cy="200" r="18" fill="rgba(79, 70, 229, 0.45)" />
+  <circle cx="524" cy="656" r="20" fill="rgba(96, 165, 250, 0.4)" />
+  <path d="M96 664C96 615.399 135.399 576 184 576H208V640C208 658.225 193.225 673 175 673H96V664Z" fill="rgba(30, 64, 175, 0.35)" />
+</svg>

--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -1,0 +1,39 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 67 >>
+stream
+BT
+/F1 24 Tf
+72 700 Td
+(Resume placeholder document) Tj
+/F1 12 Tf
+0 -32 Td
+(Replace this file with your latest resume.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000116 00000 n 
+0000000239 00000 n 
+0000000380 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+461
+%%EOF

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ContactSection from "@/components/contact-section";
+import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
@@ -6,6 +7,7 @@ import SkillsSection from "@/components/skills-section";
 export default function Home() {
   return (
     <main className="space-y-2">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,95 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowDownToLine, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const highlights = [
+  {
+    label: "Experience",
+    value: "8+ years leading design & engineering teams",
+  },
+  {
+    label: "Focus",
+    value: "Product design, full-stack systems & AI workflows",
+  },
+  {
+    label: "Availability",
+    value: "Consulting engagements & fractional leadership",
+  },
+];
+
+export default function HeroSection() {
+  return (
+    <section
+      id="about"
+      className="relative overflow-hidden bg-gradient-to-b from-background via-background to-muted/30"
+    >
+      <div className="absolute inset-x-0 top-0 -z-10 h-[720px] bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_65%)]" />
+      <div className="mx-auto flex max-w-6xl flex-col-reverse items-center gap-16 px-4 py-16 sm:px-6 lg:flex-row lg:items-stretch lg:px-8 lg:py-24">
+        <div className="flex w-full flex-1 flex-col justify-center">
+          <div className="inline-flex items-center gap-3 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm text-muted-foreground shadow-sm backdrop-blur">
+            <span className="relative flex h-2.5 w-2.5 items-center justify-center">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" aria-hidden />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
+            </span>
+            <span className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-primary" aria-hidden />
+              Product Designer & Full-Stack Engineer
+            </span>
+          </div>
+
+          <h1 className="mt-8 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+            Building polished, resilient digital products that scale
+          </h1>
+          <p className="mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+            I partner with founders and product teams to craft thoughtful experiences, ship reliable software, and weave AI-assistive workflows that keep teams focused on what matters most.
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center gap-4">
+            <Button asChild size="lg" className="shadow-lg shadow-primary/20">
+              <Link href="/resume.pdf" download>
+                <ArrowDownToLine className="h-4 w-4" aria-hidden />
+                Download Resume
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="border-border/70 bg-background/60 backdrop-blur">
+              <Link href="#projects">View Projects</Link>
+            </Button>
+          </div>
+
+          <dl className="mt-12 grid w-full gap-6 sm:grid-cols-3">
+            {highlights.map((highlight) => (
+              <div
+                key={highlight.label}
+                className="rounded-2xl border border-border/60 bg-background/80 p-6 shadow-sm backdrop-blur"
+              >
+                <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+                  {highlight.label}
+                </dt>
+                <dd className="mt-3 text-sm text-foreground/90">{highlight.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="relative flex w-full max-w-sm flex-1 items-center justify-center">
+          <div className="relative h-[420px] w-full max-w-[360px]">
+            <div className="absolute inset-0 -z-10 rounded-[3rem] bg-gradient-to-br from-primary/40 via-primary/20 to-transparent blur-3xl" aria-hidden />
+            <div className="relative h-full w-full overflow-hidden rounded-[2.5rem] border border-white/10 bg-background/70 p-4 shadow-2xl shadow-primary/30 backdrop-blur">
+              <div className="relative h-full w-full overflow-hidden rounded-[2rem] bg-gradient-to-br from-muted/50 via-background to-background">
+                <Image
+                  src="/profile-portrait.svg"
+                  alt="Portrait of Ayaan Malik"
+                  fill
+                  priority
+                  className="object-cover"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a polished hero section featuring role headline, bio, CTAs, and capability highlights
- introduce supporting illustration asset and placeholder resume download for quick access
- wire the hero section into the home page layout ahead of existing service, project, skills, and contact content

## Testing
- `npm install` *(fails: 403 Forbidden when fetching @tiptap/react)*

------
https://chatgpt.com/codex/tasks/task_e_68ef43235480832797e48ab6f6fab17e