### PR TITLE
Add hero banner with resume download CTA

### DIFF
--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,43 @@
+<svg width="640" height="853" viewBox="0 0 640 853" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paint0_linear" x1="84" y1="52" x2="556" y2="801" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2E7CF6" />
+      <stop offset="0.5" stop-color="#5B4BFA" />
+      <stop offset="1" stop-color="#F89CFF" />
+    </linearGradient>
+    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(214 146) rotate(45) scale(420 320)">
+      <stop stop-color="#FFFFFF" stop-opacity="0.4" />
+      <stop offset="1" stop-color="#121826" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="paint2_linear" x1="320" y1="180" x2="320" y2="760" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#101827" />
+      <stop offset="1" stop-color="#1C2A42" />
+    </linearGradient>
+    <filter id="shadow" x="82" y="140" width="476" height="600" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feGaussianBlur in="SourceAlpha" stdDeviation="15" result="blur" />
+      <feComposite in2="blur" operator="in" result="effect1_foregroundBlur" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_foregroundBlur" result="shape" />
+    </filter>
+  </defs>
+  <rect x="24" y="24" width="592" height="805" rx="112" fill="#0B1220" />
+  <rect x="24" y="24" width="592" height="805" rx="112" stroke="url(#paint0_linear)" stroke-width="2" opacity="0.5" />
+  <rect x="24" y="24" width="592" height="805" rx="112" fill="url(#paint1_radial)" />
+  <g filter="url(#shadow)">
+    <rect x="112" y="170" width="416" height="540" rx="144" fill="url(#paint2_linear)" />
+  </g>
+  <path d="M320 260C374.915 260 420 215.048 420 160C420 104.952 374.915 60 320 60C265.085 60 220 104.952 220 160C220 215.048 265.085 260 320 260Z" fill="#F4F7FB" fill-opacity="0.94" />
+  <path d="M320 288C247.307 288 188 347.307 188 420V540C188 612.693 247.307 672 320 672C392.693 672 452 612.693 452 540V420C452 347.307 392.693 288 320 288Z" fill="#1C2840" />
+  <path d="M320 312C360.869 312 394 278.869 394 238C394 197.131 360.869 164 320 164C279.131 164 246 197.131 246 238C246 278.869 279.131 312 320 312Z" fill="#141D32" opacity="0.8" />
+  <path d="M320 612C376.571 612 422 566.571 422 510C422 453.429 376.571 408 320 408C263.429 408 218 453.429 218 510C218 566.571 263.429 612 320 612Z" fill="#141D32" opacity="0.85" />
+  <path d="M190 572C197.115 516.357 232.831 470.523 284 450C335.169 429.477 392.831 429.477 444 450C495.169 470.523 530.885 516.357 538 572C516.667 607.333 461.6 631 384 631H256C178.4 631 123.333 607.333 102 572Z" fill="#10192C" opacity="0.8" />
+  <path d="M321 208C352.376 208 378 182.376 378 151C378 119.624 352.376 94 321 94C289.624 94 264 119.624 264 151C264 182.376 289.624 208 321 208Z" fill="#EDB8A6" opacity="0.85" />
+  <ellipse cx="284" cy="244" rx="18" ry="12" fill="#E8EEF9" opacity="0.7" />
+  <ellipse cx="360" cy="244" rx="18" ry="12" fill="#E8EEF9" opacity="0.7" />
+  <path d="M300 244C300 240.686 302.686 238 306 238H334C337.314 238 340 240.686 340 244C340 247.314 337.314 250 334 250H306C302.686 250 300 247.314 300 244Z" fill="#0F172A" opacity="0.6" />
+  <path d="M256 342C256 329.85 265.85 320 278 320H362C374.15 320 384 329.85 384 342V378C384 389.046 375.046 398 364 398H276C264.954 398 256 389.046 256 378V342Z" fill="#0D1525" opacity="0.85" />
+  <rect x="208" y="588" width="224" height="152" rx="64" fill="#111B2F" />
+  <path d="M240 660C240 627.863 265.863 602 298 602H342C374.137 602 400 627.863 400 660C400 692.137 374.137 718 342 718H298C265.863 718 240 692.137 240 660Z" fill="#1B2B45" />
+  <path d="M312 458C320.837 458 328 450.837 328 442C328 433.163 320.837 426 312 426C303.163 426 296 433.163 296 442C296 450.837 303.163 458 312 458Z" fill="#F3D0BE" opacity="0.85" />
+  <path d="M356 458C364.837 458 372 450.837 372 442C372 433.163 364.837 426 356 426C347.163 426 340 433.163 340 442C340 450.837 347.163 458 356 458Z" fill="#F3D0BE" opacity="0.85" />
+</svg>

--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -1,0 +1,41 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 159 >>
+stream
+BT
+/F1 24 Tf
+100 720 Td
+(Your Name \050UX Engineer\051) Tj
+0 -36 Td
+/F1 14 Tf
+(Resume placeholder for download) Tj
+0 -28 Td
+(Replace with your full CV.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000450 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+520
+%%EOF

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import HeroSection from "@/components/hero-section";
 import ContactSection from "@/components/contact-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
@@ -6,6 +7,7 @@ import SkillsSection from "@/components/skills-section";
 export default function Home() {
   return (
     <main className="space-y-2">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,93 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowDownToLine, Mail } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export default function HeroSection() {
+  return (
+    <section
+      id="home"
+      className="relative isolate overflow-hidden bg-gradient-to-br from-background via-background to-muted/60"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.16),_transparent_55%)]" aria-hidden />
+      <div className="mx-auto grid max-w-6xl items-center gap-16 px-4 pb-20 pt-24 sm:px-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)] lg:gap-20 lg:px-8 lg:pt-28">
+        <div className="space-y-8">
+          <div className="space-y-4">
+            <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary/80">
+              Product Designer & Engineer
+            </span>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              Crafting human-centered digital experiences that scale
+            </h1>
+            <p className="max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              I blend product strategy, design systems, and full-stack engineering to launch purposeful experiences that feel as good as they perform.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <Button asChild className="px-6 py-3 text-sm font-semibold">
+              <Link href="/resume.pdf" download>
+                <ArrowDownToLine className="size-4" aria-hidden />
+                Download résumé
+              </Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="border-primary/40 bg-background/80 px-6 py-3 text-sm font-semibold backdrop-blur-sm hover:bg-primary/10"
+            >
+              <Link href="#contact">
+                <Mail className="size-4" aria-hidden />
+                Let&apos;s collaborate
+              </Link>
+            </Button>
+          </div>
+
+          <dl className="grid gap-6 sm:grid-cols-3">
+            <div className="rounded-2xl border border-primary/20 bg-background/80 p-6 shadow-sm backdrop-blur">
+              <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-primary/70">
+                Experience
+              </dt>
+              <dd className="mt-3 text-2xl font-semibold text-foreground">8+ years</dd>
+              <p className="mt-1 text-xs text-muted-foreground">Leading product and engineering teams across startups and enterprises.</p>
+            </div>
+            <div className="rounded-2xl border border-primary/20 bg-background/80 p-6 shadow-sm backdrop-blur">
+              <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-primary/70">
+                Platforms launched
+              </dt>
+              <dd className="mt-3 text-2xl font-semibold text-foreground">25+</dd>
+              <p className="mt-1 text-xs text-muted-foreground">From MVPs to enterprise-scale ecosystems shipped globally.</p>
+            </div>
+            <div className="rounded-2xl border border-primary/20 bg-background/80 p-6 shadow-sm backdrop-blur">
+              <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-primary/70">
+                Recognition
+              </dt>
+              <dd className="mt-3 text-2xl font-semibold text-foreground">4 awards</dd>
+              <p className="mt-1 text-xs text-muted-foreground">Honored for design craft, accessibility, and innovation excellence.</p>
+            </div>
+          </dl>
+        </div>
+
+        <div className="relative mx-auto w-full max-w-md">
+          <div className="absolute inset-0 -z-10 rounded-[2.5rem] bg-gradient-to-br from-primary/15 via-primary/5 to-transparent blur-3xl" aria-hidden />
+          <div className="relative overflow-hidden rounded-[2.5rem] border border-primary/20 bg-background/90 p-4 shadow-xl backdrop-blur">
+            <div className="rounded-[2rem] bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6">
+              <div className="relative aspect-[3/4] overflow-hidden rounded-[1.75rem] border border-white/5 bg-slate-900/60">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.2),transparent_55%)]" aria-hidden />
+                <Image
+                  src="/profile-portrait.svg"
+                  alt="Portrait of a digital product designer and engineer"
+                  fill
+                  priority
+                  sizes="(min-width: 1024px) 360px, (min-width: 768px) 320px, 100vw"
+                  className="object-cover"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a polished hero section with professional messaging, CTAs, and stat highlights
- update the homepage to surface the new hero ahead of existing sections
- include supporting portrait artwork and a downloadable résumé placeholder asset

## Testing
- `npm run lint` *(fails: missing local dependency setup; npm install blocked by registry access constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68ef43235480832797e48ab6f6fab17e