### PR TITLE
Add hero banner section to homepage

### DIFF
--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,55 @@
+<svg width="480" height="560" viewBox="0 0 480 560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="560" rx="56" fill="url(#paint0_radial_hero)" />
+  <g filter="url(#filter0_d_hero)">
+    <path d="M240 140C280.421 140 315.296 165.234 333.732 202.655C340.056 215.449 343.36 229.758 343.36 244.256V247.968C343.36 284.313 335.319 319.959 319.865 351.273C304.218 382.99 281.55 408.178 253.236 421.433L245.706 424.915C242.512 426.393 238.848 426.39 235.656 424.905L227.713 421.114C199.676 407.748 177.294 382.087 161.842 350.133C146.624 318.659 138.72 283.404 138.72 246.715V244.256C138.72 197.699 173.443 160 217.759 147.837C224.894 145.842 232.4 144.832 240 144.832L240 140Z" fill="url(#paint1_linear_hero)" />
+  </g>
+  <g filter="url(#filter1_d_hero)">
+    <path d="M240.003 311.207C281.362 311.207 320.43 324.881 351.034 349.123C363.59 359.104 368.316 376.172 362.635 391.486C351.507 421.918 327.678 452.439 290.298 456.558C272.055 458.549 255.636 458.939 240.003 458.939C224.358 458.939 207.925 458.547 189.662 456.553C152.267 452.43 128.432 421.898 117.312 391.451C111.639 376.144 116.372 359.089 128.928 349.113C159.556 324.877 198.639 311.207 240.003 311.207Z" fill="url(#paint2_linear_hero)" />
+  </g>
+  <path d="M240 282.908C213.295 282.908 191.6 261.227 191.6 234.536V218.384C191.6 191.693 213.295 170.012 240 170.012C266.705 170.012 288.4 191.693 288.4 218.384V234.536C288.4 261.227 266.705 282.908 240 282.908Z" fill="url(#paint3_linear_hero)" />
+  <circle cx="196" cy="226" r="10" fill="#1B1B1F" fill-opacity="0.25" />
+  <circle cx="284" cy="226" r="10" fill="#1B1B1F" fill-opacity="0.25" />
+  <path d="M219.75 247.625C223.259 253.314 230.696 257.06 240 257.06C249.304 257.06 256.741 253.314 260.25 247.625" stroke="#0F172A" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.18" />
+  <defs>
+    <filter id="filter0_d_hero" x="118.72" y="120" width="244.64" height="327.064" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
+      <feOffset dy="12" />
+      <feGaussianBlur stdDeviation="10" />
+      <feComposite in2="hardAlpha" operator="out" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.0784314 0 0 0 0 0.160784 0 0 0 0.12 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_hero" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_hero" result="shape" />
+    </filter>
+    <filter id="filter1_d_hero" x="94.7656" y="291.207" width="290.114" height="189.731" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
+      <feOffset dy="8" />
+      <feGaussianBlur stdDeviation="10" />
+      <feComposite in2="hardAlpha" operator="out" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.0784314 0 0 0 0 0.160784 0 0 0 0.12 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_hero" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_hero" result="shape" />
+    </filter>
+    <radialGradient id="paint0_radial_hero" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(90 62) rotate(36.6549) scale(496.962 410.408)">
+      <stop stop-color="#F5F5F7" />
+      <stop offset="0.55" stop-color="#EEF1F8" />
+      <stop offset="1" stop-color="#E1E6F2" />
+    </radialGradient>
+    <linearGradient id="paint1_linear_hero" x1="240" y1="140" x2="240" y2="424.915" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.9" />
+      <stop offset="0.5" stop-color="#CBD5F5" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#94A3B8" stop-opacity="0.8" />
+    </linearGradient>
+    <linearGradient id="paint2_linear_hero" x1="240.003" y1="311.207" x2="240.003" y2="458.939" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.92" />
+      <stop offset="0.6" stop-color="#C7D2FE" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#94A3B8" stop-opacity="0.85" />
+    </linearGradient>
+    <linearGradient id="paint3_linear_hero" x1="240" y1="170.012" x2="240" y2="282.908" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FAFC" stop-opacity="0.95" />
+      <stop offset="0.65" stop-color="#DBEAFE" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#BFDBFE" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -1,0 +1,39 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 73 >>
+stream
+BT
+/F1 24 Tf
+72 700 Td
+(Alex Morgan \255 Portfolio Resume Placeholder) Tj
+/F1 14 Tf
+0 -28 Td
+(Replace this file with your full resume before sharing.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000114 00000 n 
+0000000273 00000 n 
+0000000422 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+482
+%%EOF

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import ContactSection from "@/components/contact-section";
+import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
 
 export default function Home() {
   return (
-    <main className="space-y-2">
+    <main className="space-y-24">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,123 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowDownToLine, Sparkles, UserRoundCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const roles = [
+  "Product Designer",
+  "Full-stack Engineer",
+  "AI Workflow Strategist",
+];
+
+const highlights = [
+  {
+    label: "Years of experience",
+    value: "8+",
+  },
+  {
+    label: "Products launched",
+    value: "25",
+  },
+  {
+    label: "Teams empowered",
+    value: "15",
+  },
+];
+
+export default function HeroSection() {
+  return (
+    <section
+      id="about"
+      className="relative overflow-hidden bg-background py-16 sm:py-20 lg:py-24"
+    >
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 opacity-70"
+        aria-hidden
+      >
+        <div className="absolute -left-20 top-10 h-64 w-64 rounded-full bg-primary/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-slate-300/30 blur-3xl dark:bg-slate-700/50" />
+      </div>
+
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-12 px-4 sm:px-6 md:flex-row md:gap-16 lg:px-8">
+        <div className="flex w-full flex-col gap-8 md:w-1/2">
+          <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            <Sparkles className="h-4 w-4" aria-hidden />
+            <span>Portfolio</span>
+          </div>
+
+          <div className="space-y-6">
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              Crafting thoughtful digital experiences that scale with purpose
+            </h1>
+            <p className="max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              I blend systems thinking, code craftsmanship, and AI-assisted workflows to help product teams move from idea to impact fast—without compromising on quality, accessibility, or delight.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            {roles.map((role) => (
+              <span
+                key={role}
+                className="rounded-full border border-border/80 bg-background/70 px-4 py-1 text-sm text-muted-foreground shadow-sm backdrop-blur"
+              >
+                {role}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
+            <Button asChild size="lg" className="px-6">
+              <Link href="/resume.pdf" download>
+                <ArrowDownToLine className="h-4 w-4" aria-hidden />
+                Download Resume
+              </Link>
+            </Button>
+            <Button asChild variant="ghost" size="lg" className="px-6">
+              <Link href="#contact">
+                <UserRoundCheck className="h-4 w-4" aria-hidden />
+                Book a consultation
+              </Link>
+            </Button>
+          </div>
+
+          <dl className="grid w-full gap-6 sm:grid-cols-3">
+            {highlights.map((highlight) => (
+              <div key={highlight.label} className="rounded-xl border border-border/70 bg-card/60 p-4 text-left shadow-sm backdrop-blur">
+                <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                  {highlight.label}
+                </dt>
+                <dd className="mt-2 text-2xl font-semibold text-foreground">
+                  {highlight.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="relative w-full md:w-1/2">
+          <div className="relative mx-auto max-w-sm">
+            <div className="absolute -inset-4 rounded-[2.5rem] bg-gradient-to-tr from-primary/30 via-primary/10 to-transparent blur-2xl" aria-hidden />
+            <div className="relative overflow-hidden rounded-[2.5rem] border border-border/70 bg-card shadow-xl">
+              <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-primary/20 via-transparent to-transparent" aria-hidden />
+              <Image
+                src="/profile-portrait.svg"
+                alt="Portrait of Alex Morgan"
+                width={480}
+                height={560}
+                priority
+                className="w-full object-cover"
+              />
+              <div className="space-y-1 border-t border-border/70 bg-background/90 p-6 backdrop-blur">
+                <p className="text-lg font-semibold text-foreground">Alex Morgan</p>
+                <p className="text-sm text-muted-foreground">
+                  Principal Product Designer & Engineer partnering with visionary teams worldwide.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create a dedicated hero section that showcases name, tagline, CTAs, and professional highlights
- add supporting visual assets including a stylized portrait illustration and downloadable resume placeholder
- surface the hero on the homepage and adjust spacing between sections for a polished first impression

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ef43235480832797e48ab6f6fab17e