### PR TITLE
Add professional hero banner with resume download

### DIFF
--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,37 @@
+<svg width="640" height="800" viewBox="0 0 640 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="800" rx="120" fill="url(#paint0_radial)" />
+  <g filter="url(#filter0_d)">
+    <path d="M320 184C268.002 184 224 228.002 224 280C224 331.998 268.002 376 320 376C371.998 376 416 331.998 416 280C416 228.002 371.998 184 320 184Z" fill="url(#paint1_linear)" />
+    <path d="M320 408C214.588 408 128 494.588 128 600V640C128 665.167 148.833 686 174 686H466C491.167 686 512 665.167 512 640V600C512 494.588 425.412 408 320 408Z" fill="url(#paint2_linear)" />
+  </g>
+  <rect x="48" y="48" width="544" height="704" rx="104" stroke="url(#paint3_linear)" stroke-opacity="0.6" stroke-width="8" />
+  <defs>
+    <filter id="filter0_d" x="96" y="152" width="448" height="566" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
+      <feOffset dy="24" />
+      <feGaussianBlur stdDeviation="24" />
+      <feComposite in2="hardAlpha" operator="out" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0.145098 0 0 0 0 0.282353 0 0 0 0 0.717647 0 0 0 0.16 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+    </filter>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(132 104) rotate(35) scale(732 610)">
+      <stop stop-color="#F5F8FF" />
+      <stop offset="0.42" stop-color="#E6ECFF" />
+      <stop offset="1" stop-color="#DCE4FF" />
+    </radialGradient>
+    <linearGradient id="paint1_linear" x1="320" y1="184" x2="320" y2="376" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2B52B2" />
+      <stop offset="1" stop-color="#1F3E89" />
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="320" y1="408" x2="320" y2="686" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#243B86" />
+      <stop offset="1" stop-color="#0F1F4C" />
+    </linearGradient>
+    <linearGradient id="paint3_linear" x1="48" y1="48" x2="592" y2="752" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.7" />
+      <stop offset="1" stop-color="#5F77D6" stop-opacity="0.5" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 83 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Anthony Lema - Principal Product Designer & Engineer) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000374 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+444
+%%EOF

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ContactSection from "@/components/contact-section";
+import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
@@ -6,6 +7,7 @@ import SkillsSection from "@/components/skills-section";
 export default function Home() {
   return (
     <main className="space-y-2">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,92 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowDownToLine, Mail, MapPin, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const highlights = [
+  "Design systems that elevate complex products",
+  "Full-stack engineering grounded in UX craft",
+  "AI-assisted workflows that accelerate delivery",
+];
+
+export default function HeroSection() {
+  return (
+    <section
+      id="about"
+      className="relative overflow-hidden bg-gradient-to-b from-background via-background to-muted/40"
+    >
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-y-0 right-0 w-2/3 bg-[radial-gradient(circle_at_top,_theme(colors.primary/10),_transparent_65%)]" />
+        <div className="absolute -left-40 top-1/2 size-[28rem] -translate-y-1/2 rounded-full bg-primary/10 blur-3xl" />
+      </div>
+
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-12 px-4 py-16 sm:px-6 lg:flex-row lg:py-24 lg:px-8">
+        <div className="flex-1 space-y-8 text-center lg:text-left">
+          <span className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary/80">
+            <Sparkles className="size-3" aria-hidden />
+            Product Designer &amp; Full-stack Engineer
+          </span>
+
+          <div className="space-y-4">
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              Crafting intentional digital experiences that balance strategy, design, and code.
+            </h1>
+            <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+              I help venture-backed teams move from concept to scale with design systems, engineering rigor, and AI-enabled workflows that keep user value at the center.
+            </p>
+          </div>
+
+          <div className="flex flex-col items-center gap-4 text-sm text-muted-foreground lg:flex-row lg:items-center lg:gap-8">
+            <span className="inline-flex items-center gap-2">
+              <MapPin className="size-4 text-primary" aria-hidden />
+              Remote · Open to global collaborations
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <Mail className="size-4 text-primary" aria-hidden />
+              hello@antholem.studio
+            </span>
+          </div>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center lg:justify-start">
+            <Button asChild size="lg">
+              <Link href="/resume.pdf" download>
+                <ArrowDownToLine className="size-4" aria-hidden />
+                Download resume
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href="#contact">Discuss a project</Link>
+            </Button>
+          </div>
+
+          <div className="grid w-full gap-3 sm:grid-cols-3">
+            {highlights.map((highlight) => (
+              <div
+                key={highlight}
+                className="rounded-xl border border-border/60 bg-background/60 p-4 text-sm text-muted-foreground shadow-sm backdrop-blur"
+              >
+                {highlight}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="relative flex-1">
+          <div className="mx-auto size-[18rem] max-w-full rounded-[2.5rem] border border-border/50 bg-background/80 p-4 shadow-xl backdrop-blur md:size-[22rem]">
+            <div className="relative h-full w-full overflow-hidden rounded-[2rem] bg-gradient-to-br from-primary/20 via-primary/5 to-background">
+              <Image
+                src="/profile-portrait.svg"
+                alt="Portrait of Anthony Lema, product designer and engineer"
+                fill
+                priority
+                className="object-cover object-top"
+                sizes="(min-width: 1024px) 22rem, 18rem"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a hero section that introduces the portfolio with role, biography, contact details, and calls to action
- include a downloadable resume link and supporting profile illustration for the new banner

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ef43235480832797e48ab6f6fab17e