### PR TITLE
Add hero banner to portfolio landing page

### DIFF
--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,46 @@
+<svg width="480" height="640" viewBox="0 0 480 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="640" rx="48" fill="url(#paint0_linear)"/>
+  <g filter="url(#filter0_d)">
+    <circle cx="240" cy="212" r="104" fill="url(#paint1_linear)"/>
+  </g>
+  <path d="M240 328C169.848 328 112 385.848 112 456V488C112 502.359 123.641 514 138 514H342C356.359 514 368 502.359 368 488V456C368 385.848 310.152 328 240 328Z" fill="url(#paint2_linear)"/>
+  <circle cx="240" cy="212" r="96" fill="url(#paint3_radial)"/>
+  <path d="M240 128C282.183 128 316 161.817 316 204C316 246.183 282.183 280 240 280C197.817 280 164 246.183 164 204C164 161.817 197.817 128 240 128Z" fill="url(#paint4_linear)"/>
+  <path d="M240 158C255.464 158 268 170.536 268 186C268 201.464 255.464 214 240 214C224.536 214 212 201.464 212 186C212 170.536 224.536 158 240 158Z" fill="url(#paint5_linear)"/>
+  <defs>
+    <filter id="filter0_d" x="96" y="96" width="288" height="288" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="12"/>
+      <feGaussianBlur stdDeviation="16"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0470588 0 0 0 0 0.121569 0 0 0 0 0.258824 0 0 0 0.16 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <linearGradient id="paint0_linear" x1="48" y1="48" x2="432" y2="592" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#121826"/>
+      <stop offset="1" stop-color="#1F2937"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="168" y1="108" x2="312" y2="316" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4F46E5"/>
+      <stop offset="1" stop-color="#A855F7"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear" x1="112" y1="328" x2="368" y2="512" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <radialGradient id="paint3_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 164) rotate(90) scale(172)">
+      <stop offset="0.16" stop-color="#1F2937" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#111827" stop-opacity="0.36"/>
+    </radialGradient>
+    <linearGradient id="paint4_linear" x1="188" y1="140" x2="316" y2="280" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F9FAFB"/>
+      <stop offset="1" stop-color="#E5E7EB"/>
+    </linearGradient>
+    <linearGradient id="paint5_linear" x1="220" y1="168" x2="268" y2="214" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDF2F8"/>
+      <stop offset="1" stop-color="#F5D0FE"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ContactSection from "@/components/contact-section";
+import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
@@ -6,6 +7,7 @@ import SkillsSection from "@/components/skills-section";
 export default function Home() {
   return (
     <main className="space-y-2">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,104 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight, Download, Github, Linkedin, Mail } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const socials = [
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/janedoe",
+    icon: Linkedin,
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/janedoe",
+    icon: Github,
+  },
+  {
+    label: "Email",
+    href: "mailto:hello@janedoe.design",
+    icon: Mail,
+  },
+];
+
+export default function HeroSection() {
+  return (
+    <section
+      id="home"
+      className="relative overflow-hidden bg-gradient-to-b from-background via-background to-muted/40"
+    >
+      <div className="mx-auto flex max-w-6xl flex-col-reverse gap-12 px-4 py-20 sm:px-6 lg:flex-row lg:items-center lg:gap-16 lg:px-8 lg:py-28">
+        <div className="space-y-8 lg:w-1/2">
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+              Portfolio of Jane Doe
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              Product Designer & Full-stack Engineer
+            </h1>
+            <p className="max-w-xl text-base text-muted-foreground sm:text-lg">
+              I build immersive digital products that blend thoughtful experience design with resilient engineering. From design systems to end-to-end applications, I help teams ship faster and smarter.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button asChild size="lg">
+              <Link href="#projects">
+                View Projects
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href="/resume.pdf">
+                Download Résumé
+                <Download className="h-4 w-4" aria-hidden />
+              </Link>
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-muted-foreground">
+              <p className="font-semibold text-foreground">Currently partnering with</p>
+              <p>High-growth teams to craft human-centered products.</p>
+            </div>
+            <div className="flex items-center gap-3">
+              {socials.map((social) => (
+                <Link
+                  key={social.href}
+                  href={social.href}
+                  aria-label={social.label}
+                  className="inline-flex size-10 items-center justify-center rounded-full border border-border text-muted-foreground transition hover:border-primary/60 hover:text-primary"
+                >
+                  <social.icon className="h-4 w-4" aria-hidden />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="relative mx-auto flex max-w-sm items-center justify-center lg:mx-0 lg:w-1/2">
+          <div className="absolute inset-0 -z-10 rounded-full bg-primary/10 blur-3xl" aria-hidden />
+          <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-background/60 p-4 shadow-2xl backdrop-blur">
+            <div className="rounded-[1.5rem] bg-gradient-to-br from-muted to-background p-4">
+              <Image
+                src="/profile-portrait.svg"
+                alt="Portrait of Jane Doe"
+                priority
+                width={480}
+                height={640}
+                className="h-auto w-full"
+              />
+            </div>
+            <div className="mt-4 flex items-center justify-between rounded-2xl bg-primary/5 px-4 py-3 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">Based in New York</span>
+              <span>Open to remote collaborations</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background to-transparent" aria-hidden />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated hero section with introduction, calls-to-action, and social links for the landing page
- integrate the hero banner at the top of the home layout for immediate visibility
- include a custom portrait illustration asset used within the hero presentation

## Testing
- npm run lint *(fails: missing dependency `@eslint/eslintrc` required by existing config)*

------
https://chatgpt.com/codex/tasks/task_e_68ef4bc8b4d0832799a939f5cbf97d5b