### PR TITLE
Add hero banner section to portfolio home page

### DIFF
--- a/public/hero-portrait.svg
+++ b/public/hero-portrait.svg
@@ -1,0 +1,35 @@
+<svg width="640" height="800" viewBox="0 0 640 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="640" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="50%" stop-color="#1e1b4b" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="15%" r="70%">
+      <stop offset="0%" stop-color="#e0f2fe" stop-opacity="0.6" />
+      <stop offset="70%" stop-color="#60a5fa" stop-opacity="0.15" />
+      <stop offset="100%" stop-color="#0f172a" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="skin" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fbe8d3" />
+      <stop offset="100%" stop-color="#f2c8a2" />
+    </linearGradient>
+    <linearGradient id="jacket" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="800" rx="56" fill="url(#bg)" />
+  <rect width="640" height="800" rx="56" fill="url(#glow)" />
+  <g filter="url(#shadow)">
+    <circle cx="320" cy="248" r="132" fill="url(#skin)" />
+    <path d="M258 382c-46 0-86 38-86 84v56c0 62 60 116 148 116s148-54 148-116v-56c0-46-40-84-86-84H258z" fill="white" fill-opacity="0.85" />
+    <path d="M225 427c23 17 58 29 95 29 37 0 72-12 95-29v-15c0-38-31-69-69-69h-52c-38 0-69 31-69 69v15z" fill="url(#jacket)" />
+    <path d="M320 134c-74 0-116 48-116 128 0 22 3 39 8 52h216c5-13 8-30 8-52 0-80-42-128-116-128z" fill="#0f172a" />
+  </g>
+  <defs>
+    <filter id="shadow" x="100" y="80" width="440" height="580" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#0f172a" flood-opacity="0.35" />
+    </filter>
+  </defs>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ContactSection from "@/components/contact-section";
+import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
@@ -6,6 +7,7 @@ import SkillsSection from "@/components/skills-section";
 export default function Home() {
   return (
     <main className="space-y-2">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,117 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight, Github, Linkedin, Mail, Rss } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const socialLinks = [
+  {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/in/antholem",
+    icon: Linkedin,
+  },
+  {
+    name: "GitHub",
+    href: "https://github.com/antholem",
+    icon: Github,
+  },
+  {
+    name: "Newsletter",
+    href: "https://antholem.com/newsletter",
+    icon: Rss,
+  },
+  {
+    name: "Email",
+    href: "mailto:hello@antholem.com",
+    icon: Mail,
+  },
+] as const;
+
+export default function HeroSection() {
+  return (
+    <section id="hero" className="bg-gradient-to-b from-background via-background to-muted/40">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-16 px-4 py-20 sm:px-6 md:flex-row md:py-24 lg:px-8">
+        <div className="flex-1 space-y-10 text-center md:text-left">
+          <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-xs font-medium uppercase tracking-[0.35em] text-primary">
+            <span className="size-2 rounded-full bg-primary" aria-hidden />
+            Currently welcoming product collaborations
+          </div>
+
+          <div className="space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/70">
+              Anthony Olem
+            </p>
+            <h1 className="text-4xl font-semibold leading-tight text-foreground sm:text-5xl lg:text-6xl">
+              Product designer & full-stack engineer crafting purposeful digital experiences
+            </h1>
+            <p className="max-w-xl text-base text-muted-foreground sm:text-lg">
+              I help founders and product teams transform complex ideas into clear, trustworthy experiences—blending strategy, design systems, and modern engineering for measurable business impact.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button asChild size="lg" className="h-12 rounded-full px-8 text-base">
+              <Link href="#projects">
+                View recent work
+                <ArrowRight className="size-4" aria-hidden />
+              </Link>
+            </Button>
+            <Button
+              asChild
+              size="lg"
+              variant="outline"
+              className="h-12 rounded-full border-border px-8 text-base"
+            >
+              <Link href="#contact">
+                Start a conversation
+                <Mail className="size-4" aria-hidden />
+              </Link>
+            </Button>
+          </div>
+
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-between md:gap-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
+              Connect with me
+            </p>
+            <div className="flex gap-3">
+              {socialLinks.map((social) => (
+                <Link
+                  key={social.name}
+                  href={social.href}
+                  aria-label={social.name}
+                  className="group inline-flex size-11 items-center justify-center rounded-full border border-border/70 bg-background/80 text-muted-foreground shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+                >
+                  <social.icon className="size-4 transition-transform group-hover:scale-110" aria-hidden />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="relative flex-1">
+          <div className="relative mx-auto max-w-sm">
+            <div className="relative aspect-[4/5] w-full overflow-hidden rounded-[2.5rem] border border-border/60 bg-gradient-to-br from-primary/20 via-background to-background shadow-2xl shadow-primary/10">
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.45),_transparent_55%)]" aria-hidden />
+              <Image
+                src="/hero-portrait.svg"
+                alt="Portrait illustration of Anthony Olem"
+                fill
+                priority
+                sizes="(min-width: 1024px) 360px, (min-width: 768px) 320px, 280px"
+                className="object-cover object-top"
+              />
+            </div>
+            <div className="absolute -bottom-6 left-1/2 w-full max-w-[260px] -translate-x-1/2 rounded-3xl border border-border/60 bg-background/95 p-4 text-center shadow-xl backdrop-blur">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary/70">
+                Expertise snapshot
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Product strategy · Design systems · Full-stack delivery
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated hero section featuring a headline, CTAs, social links, and supporting highlight card
- include an illustrative portrait asset for the hero layout and wire it into the home page flow

## Testing
- npm run lint *(fails: missing dependency `@eslint/eslintrc` in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef4bc8b4d0832799a939f5cbf97d5b