### PR TITLE
Add hero section to portfolio landing page

### DIFF
--- a/public/profile-portrait.svg
+++ b/public/profile-portrait.svg
@@ -1,0 +1,41 @@
+<svg width="480" height="560" viewBox="0 0 480 560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="560" rx="36" fill="url(#paint0_linear_1_1)"/>
+  <g filter="url(#filter0_d_1_1)">
+    <circle cx="240" cy="200" r="112" fill="url(#paint1_radial_1_1)"/>
+  </g>
+  <path d="M153 408C153 344.772 204.772 293 268 293H212C275.228 293 327 344.772 327 408V436C327 456.539 310.539 473 290 473H190C169.461 473 153 456.539 153 436V408Z" fill="url(#paint2_linear_1_1)"/>
+  <path d="M240 120C197.295 120 163 154.295 163 197C163 239.705 197.295 274 240 274C282.705 274 317 239.705 317 197C317 154.295 282.705 120 240 120ZM240 150C265.405 150 286 170.595 286 196C286 221.405 265.405 242 240 242C214.595 242 194 221.405 194 196C194 170.595 214.595 150 240 150Z" fill="url(#paint3_linear_1_1)"/>
+  <path d="M160 440C180 400 210 380 240 380C270 380 300 400 320 440" stroke="url(#paint4_linear_1_1)" stroke-width="18" stroke-linecap="round"/>
+  <defs>
+    <filter id="filter0_d_1_1" x="88" y="62" width="304" height="304" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="16"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0470588 0 0 0 0 0.141176 0 0 0 0 0.247059 0 0 0 0.08 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+    <linearGradient id="paint0_linear_1_1" x1="0" y1="0" x2="480" y2="560" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <radialGradient id="paint1_radial_1_1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(228 158) rotate(65.2279) scale(171.57)">
+      <stop stop-color="#38BDF8"/>
+      <stop offset="0.52" stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </radialGradient>
+    <linearGradient id="paint2_linear_1_1" x1="153" y1="293" x2="327" y2="473" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1E293B"/>
+      <stop offset="1" stop-color="#0F172A"/>
+    </linearGradient>
+    <linearGradient id="paint3_linear_1_1" x1="163" y1="120" x2="317" y2="274" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E0F2FE"/>
+      <stop offset="1" stop-color="#BAE6FD"/>
+    </linearGradient>
+    <linearGradient id="paint4_linear_1_1" x1="160" y1="380" x2="320" y2="440" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38BDF8"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ContactSection from "@/components/contact-section";
+import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
 import ServicesSection from "@/components/services-section";
 import SkillsSection from "@/components/skills-section";
@@ -6,6 +7,7 @@ import SkillsSection from "@/components/skills-section";
 export default function Home() {
   return (
     <main className="space-y-2">
+      <HeroSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -49,7 +49,7 @@ export default function HeroSection() {
               </Link>
             </Button>
             <Button asChild size="lg" variant="outline" className="px-6">
-              <Link href="#contact">Let&apos;s Collaborate</Link>
+              <Link href="#contact">Download Resume</Link>
             </Button>
           </div>
 

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -31,30 +31,15 @@ export default function HeroSection() {
         <div className="flex-1 space-y-10">
           <div className="space-y-4">
             <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
-              Antholem Lem Manalo
+              Sam Antholem Manalo
             </p>
             <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
-              Product Designer &amp; Full-Stack Engineer
+              Software Engineer
             </h1>
             <p className="max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
               I design and build resilient digital platforms that balance delightful experiences with reliable engineering. My practice combines systems thinking, accessibility, and AI-assisted workflows to deliver measurable business impact.
             </p>
           </div>
-
-          <ul className="flex flex-wrap gap-3 text-sm font-medium text-muted-foreground">
-            {[
-              "Design Systems",
-              "Next.js &amp; TypeScript",
-              "AI Product Strategy",
-            ].map((item) => (
-              <li
-                key={item}
-                className="rounded-full bg-primary/10 px-4 py-2 text-xs uppercase tracking-[0.25em] text-primary"
-              >
-                {item}
-              </li>
-            ))}
-          </ul>
 
           <div className="flex flex-wrap gap-4">
             <Button asChild size="lg" className="px-6">
@@ -74,7 +59,7 @@ export default function HeroSection() {
                 Currently based in
               </p>
               <p className="mt-1 text-base font-medium text-foreground">
-                Mabalacat, Pampanga, Philippines
+                Clark, Pampanga, Philippines
               </p>
             </div>
             <div className="flex gap-3">
@@ -101,7 +86,7 @@ export default function HeroSection() {
           <div className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-slate-950/60 shadow-2xl backdrop-blur">
             <Image
               src="/profile-portrait.svg"
-              alt="Illustrated portrait of Antholem Lem Manalo"
+              alt="Illustrated portrait of Sam Antholem Manalo"
               width={480}
               height={560}
               priority

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,0 +1,115 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { ArrowDownRight, Github, Linkedin, Mail } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const socialLinks = [
+  {
+    name: "GitHub",
+    href: "https://github.com/antholem",
+    icon: Github,
+  },
+  {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/in/antholem",
+    icon: Linkedin,
+  },
+  {
+    name: "Email",
+    href: "mailto:antholemlemmanalo@gmail.com",
+    icon: Mail,
+  },
+] as const;
+
+export default function HeroSection() {
+  return (
+    <section id="home" className="relative overflow-hidden bg-background">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15),_transparent_55%),_radial-gradient(circle_at_bottom,_rgba(14,165,233,0.12),_transparent_60%)]" aria-hidden />
+      <div className="mx-auto flex max-w-6xl flex-col-reverse items-center gap-12 px-4 py-24 sm:px-6 lg:flex-row lg:items-start lg:py-28">
+        <div className="flex-1 space-y-10">
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+              Antholem Lem Manalo
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+              Product Designer &amp; Full-Stack Engineer
+            </h1>
+            <p className="max-w-xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              I design and build resilient digital platforms that balance delightful experiences with reliable engineering. My practice combines systems thinking, accessibility, and AI-assisted workflows to deliver measurable business impact.
+            </p>
+          </div>
+
+          <ul className="flex flex-wrap gap-3 text-sm font-medium text-muted-foreground">
+            {[
+              "Design Systems",
+              "Next.js &amp; TypeScript",
+              "AI Product Strategy",
+            ].map((item) => (
+              <li
+                key={item}
+                className="rounded-full bg-primary/10 px-4 py-2 text-xs uppercase tracking-[0.25em] text-primary"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-wrap gap-4">
+            <Button asChild size="lg" className="px-6">
+              <Link href="#projects">
+                View Projects
+                <ArrowDownRight className="h-5 w-5" aria-hidden />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline" className="px-6">
+              <Link href="#contact">Let&apos;s Collaborate</Link>
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                Currently based in
+              </p>
+              <p className="mt-1 text-base font-medium text-foreground">
+                Mabalacat, Pampanga, Philippines
+              </p>
+            </div>
+            <div className="flex gap-3">
+              {socialLinks.map((social) => (
+                <Button
+                  key={social.name}
+                  asChild
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-full border border-transparent bg-primary/10 text-primary transition hover:border-primary/30 hover:bg-primary/20"
+                  aria-label={`Visit ${social.name}`}
+                >
+                  <Link href={social.href} target={social.name === "Email" ? undefined : "_blank"} rel={social.name === "Email" ? undefined : "noreferrer noopener"}>
+                    <social.icon className="h-5 w-5" aria-hidden />
+                  </Link>
+                </Button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="relative flex max-w-sm flex-1 items-center justify-center">
+          <div className="absolute inset-0 -z-10 rounded-[2.5rem] bg-gradient-to-br from-primary/30 via-primary/5 to-transparent blur-3xl" aria-hidden />
+          <div className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-slate-950/60 shadow-2xl backdrop-blur">
+            <Image
+              src="/profile-portrait.svg"
+              alt="Illustrated portrait of Antholem Lem Manalo"
+              width={480}
+              height={560}
+              priority
+              className="h-auto w-full object-cover"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a homepage hero banner introducing Antholem Lem Manalo with CTAs and social links
- create a custom portrait illustration asset for the hero image
- integrate the hero section into the main page above the existing content

## Testing
- npm run lint *(fails: registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef4bc8b4d0832799a939f5cbf97d5b