### PR TITLE
Add about section to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import AboutSection from "@/components/about-section";
 import ContactSection from "@/components/contact-section";
 import HeroSection from "@/components/hero-section";
 import ProjectsSection from "@/components/projects-section";
@@ -8,6 +9,7 @@ export default function Home() {
   return (
     <main className="space-y-2">
       <HeroSection />
+      <AboutSection />
       <ServicesSection />
       <ProjectsSection />
       <SkillsSection />

--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -1,0 +1,47 @@
+export default function AboutSection() {
+  const highlights = [
+    "Crafting user-first product strategies that connect technical execution with human impact.",
+    "Building modular, maintainable systems that stay flexible as ideas scale and evolve.",
+    "Facilitating discovery workshops and design critiques to keep teams aligned and inspired.",
+  ];
+
+  return (
+    <section id="about" className="py-16 lg:py-20">
+      <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-[1.15fr_1fr] lg:items-start lg:px-8">
+        <div className="space-y-6">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-primary/80">
+            About
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            Product-minded engineering with a systems thinker's lens
+          </h2>
+          <p className="text-base leading-relaxed text-muted-foreground">
+            I focus on shaping resilient digital experiences that balance craft, performance, and accessibility.
+            Beyond shipping features, I enjoy translating complex requirements into intuitive journeys and fostering
+            collaboration across product, design, and engineering.
+          </p>
+          <p className="text-base leading-relaxed text-muted-foreground">
+            There's more work I'm proud of that isn't showcased here yet—from exploratory prototypes to
+            long-running platform initiatives. If you're curious, I'd be happy to walk you through the ideas,
+            tradeoffs, and lessons that shaped them.
+          </p>
+        </div>
+
+        <div className="space-y-6 rounded-2xl border border-border bg-card/50 p-8 shadow-sm">
+          <h3 className="text-xl font-semibold text-foreground">How I like to collaborate</h3>
+          <ul className="space-y-4">
+            {highlights.map((highlight) => (
+              <li key={highlight} className="flex items-start gap-3 text-sm text-muted-foreground">
+                <span
+                  className="mt-1 inline-flex size-2 flex-shrink-0 rounded-full bg-primary"
+                  aria-hidden
+                />
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -17,7 +17,7 @@ import { useThemeStore } from "@/lib/theme-store"
 import { Separator } from "@/components/ui/separator"
 
 const links = [
-    { href: "/", label: "About" },
+    { href: "#about", label: "About" },
     { href: "#services", label: "Services" },
     { href: "#skills", label: "Skills" },
     { href: "#projects", label: "Projects" },


### PR DESCRIPTION
## Summary
- add a dedicated About section that highlights strengths and additional work not yet showcased
- include the new section in the homepage layout and update navigation to anchor to it

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68f1d97c3f2c8327b8de94c686dee3a8