### PR TITLE
Add footer section to portfolio layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import "./globals.css"
 import Navbar from "@/components/ui/navbar"
+import Footer from "@/components/ui/footer"
 import { cookies } from "next/headers"
 import type { ReactNode } from "react"
 import Script from "next/script"
@@ -54,8 +55,11 @@ export default async function RootLayout({
         </Script>
       </head>
       <body className="font-sans" suppressHydrationWarning>
-        <Navbar initialTheme={cookieTheme} />
-        <main>{children}</main>
+        <div className="flex min-h-screen flex-col">
+          <Navbar initialTheme={cookieTheme} />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
       </body>
     </html>
   );

--- a/src/components/ui/footer.tsx
+++ b/src/components/ui/footer.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+const footerLinks = [
+  { label: "Projects", href: "#projects" },
+  { label: "Services", href: "#services" },
+  { label: "Skills", href: "#skills" },
+  { label: "Contact", href: "#contact" },
+] as const;
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-border/40 bg-background/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 text-sm text-muted-foreground sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="font-semibold text-foreground">Sam Antholem Manalo</p>
+          <p className="mt-1">Building thoughtful digital experiences, one project at a time.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul className="flex flex-wrap gap-4">
+            {footerLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="transition-colors hover:text-foreground"
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <div className="flex flex-col items-start gap-1 text-xs sm:text-sm">
+          <span>© {new Date().getFullYear()} Antholem. All rights reserved.</span>
+          <Link
+            href="mailto:antholemlemmanalo@gmail.com"
+            className="transition-colors hover:text-foreground"
+          >
+            antholemlemmanalo@gmail.com
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable footer component with navigation links and contact details
- integrate the footer into the root layout and ensure the page content stretches to fill the viewport

## Testing
- npm run lint *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68f4da9b5fb48327abc9867ad2585967