### PR TITLE
feat: integrate sonner toaster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-icons": "^5.5.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "zustand": "^5.0.8"
+        "zustand": "^5.0.8",
+        "sonner": "^1.5.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-icons": "^5.5.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "sonner": "^1.5.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import "./globals.css"
 import Navbar from "@/components/ui/navbar"
+import { Toaster } from "@/components/ui/sonner"
 import { cookies } from "next/headers"
 import type { ReactNode } from "react"
 import Script from "next/script"
@@ -56,6 +57,7 @@ export default async function RootLayout({
       <body className="font-sans" suppressHydrationWarning>
         <Navbar initialTheme={cookieTheme} />
         <main>{children}</main>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -4,6 +4,7 @@ import { type ChangeEvent, FormEvent, useCallback, useEffect, useState } from 'r
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { toast } from '@/components/ui/sonner';
 import { EditorContent, type Editor as TiptapEditor, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import type { LucideIcon } from 'lucide-react';
@@ -195,7 +196,9 @@ export default function ContactForm() {
     event.preventDefault();
 
     if (!editor) {
-      setStatus({ state: 'error', message: 'Editor failed to load. Please refresh the page.' });
+      const message = 'Editor failed to load. Please refresh the page.';
+      setStatus({ state: 'error', message });
+      toast.error(message);
       return;
     }
 
@@ -203,15 +206,19 @@ export default function ContactForm() {
     const messageHtml = editor.getHTML();
 
     if (!plainMessage) {
-      setStatus({ state: 'error', message: 'Please include a message.' });
+      const message = 'Please include a message.';
+      setStatus({ state: 'error', message });
+      toast.error(message);
       return;
     }
 
     if (plainMessage.length > 5000) {
+      const message = 'Message is too long. Please keep it under 5000 characters.';
       setStatus({
         state: 'error',
-        message: 'Message is too long. Please keep it under 5000 characters.',
+        message,
       });
+      toast.error(message);
       return;
     }
 
@@ -233,13 +240,16 @@ export default function ContactForm() {
       setValues(initialValues);
       editor.commands.clearContent(true);
       updateEditorEmptyState(editor);
-      setStatus({ state: 'success', message: 'Thanks! Your message has been delivered.' });
+      const message = 'Thanks! Your message has been delivered.';
+      setStatus({ state: 'success', message });
+      toast.success(message);
     } catch (error) {
       const message =
         error instanceof Error && error.message
           ? error.message
           : 'Something went wrong while sending your message.';
       setStatus({ state: 'error', message });
+      toast.error(message);
     }
   };
 
@@ -336,9 +346,19 @@ export default function ContactForm() {
           </div>
         </CardContent>
         <CardFooter className="flex-col items-stretch gap-2 px-6 md:flex-row md:items-center md:justify-between">
-          <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
-            {isSubmitting ? 'Sending…' : 'Send message'}
-          </Button>
+          <div className="flex w-full flex-col gap-2 md:flex-row">
+            <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
+              {isSubmitting ? 'Sending…' : 'Send message'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => toast('This is a test toast from the contact form!')}
+              className="w-full justify-center md:w-auto"
+            >
+              Test toast
+            </Button>
+          </div>
           {status.message && (
             <p
               className={`text-sm ${

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -350,28 +350,7 @@ export default function ContactForm() {
             <Button type="submit" disabled={isSubmitting || !editor} className="w-full justify-center md:w-auto">
               {isSubmitting ? 'Sending…' : 'Send message'}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => toast('This is a test toast from the contact form!')}
-              className="w-full justify-center md:w-auto"
-            >
-              Test toast
-            </Button>
           </div>
-          {status.message && (
-            <p
-              className={`text-sm ${
-                status.state === 'error'
-                  ? 'text-destructive'
-                  : status.state === 'success'
-                    ? 'text-emerald-600'
-                    : 'text-muted-foreground'
-              }`}
-            >
-              {status.message}
-            </p>
-          )}
         </CardFooter>
       </form>
     </Card>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { Toaster as SonnerToaster } from "sonner"
+
+export function Toaster() {
+  return <SonnerToaster position="bottom-left" theme="dark" />
+}
+
+export { toast } from "sonner"

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -7,6 +7,7 @@ import { useThemeStore } from '@/lib/theme-store'
 
 export function Toaster() {
   const theme = useThemeStore((state) => state.theme)
+  const invertedTheme = theme === 'dark' ? 'light' : 'dark'
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -14,7 +15,10 @@ export function Toaster() {
   }, [])
 
   return (
-    <SonnerToaster position="bottom-left" theme={mounted ? theme : undefined} />
+    <SonnerToaster
+      position="bottom-left"
+      theme={mounted ? invertedTheme : undefined}
+    />
   )
 }
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,9 +1,21 @@
 'use client'
 
-import { Toaster as SonnerToaster } from "sonner"
+import { useEffect, useState } from 'react'
+import { Toaster as SonnerToaster } from 'sonner'
+
+import { useThemeStore } from '@/lib/theme-store'
 
 export function Toaster() {
-  return <SonnerToaster position="bottom-left" theme="dark" />
+  const theme = useThemeStore((state) => state.theme)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return (
+    <SonnerToaster position="bottom-left" theme={mounted ? theme : undefined} />
+  )
 }
 
-export { toast } from "sonner"
+export { toast } from 'sonner'


### PR DESCRIPTION
## Summary
- add the Sonner dependency and a wrapper component that renders a dark themed, bottom-left toaster
- mount the toaster in the root layout and wire the contact form to emit toast feedback
- add a test toast button in the contact form for quickly verifying the notification system

## Testing
- Not run (npm registry access blocked; `npm install sonner` returned 403)


------
https://chatgpt.com/codex/tasks/task_e_68f96a735c308327b9a95d7923beb15d