### PR TITLE
Add Gemini-powered message enhancement to contact form

### DIFF
--- a/src/app/api/enhance-message/route.ts
+++ b/src/app/api/enhance-message/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+import { enhanceContactMessage } from '@/lib/gemini';
+
+interface EnhanceMessageRequestBody {
+  message?: unknown;
+}
+
+const MAX_MESSAGE_LENGTH = 5000;
+
+export async function POST(request: Request) {
+  let parsedBody: EnhanceMessageRequestBody;
+
+  try {
+    parsedBody = (await request.json()) as EnhanceMessageRequestBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request payload.' }, { status: 400 });
+  }
+
+  const message = typeof parsedBody.message === 'string' ? parsedBody.message : '';
+  const trimmedMessage = message.trim();
+
+  if (!trimmedMessage) {
+    return NextResponse.json({ error: 'Please provide a message to enhance.' }, { status: 400 });
+  }
+
+  if (trimmedMessage.length > MAX_MESSAGE_LENGTH) {
+    return NextResponse.json({ error: 'Message is too long to enhance.' }, { status: 400 });
+  }
+
+  try {
+    const enhancedMessage = await enhanceContactMessage(trimmedMessage);
+    return NextResponse.json({ enhancedMessage });
+  } catch (error) {
+    console.error('Failed to enhance message with Gemini:', error);
+
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'Unable to enhance the message at this time.';
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,0 +1,104 @@
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+
+interface GenerateContentPart {
+  text?: string;
+}
+
+interface GenerateContentCandidate {
+  content?: {
+    parts?: GenerateContentPart[];
+  };
+}
+
+interface GenerateContentResponse {
+  candidates?: GenerateContentCandidate[];
+  promptFeedback?: {
+    blockReason?: string;
+  };
+  error?: {
+    message?: string;
+    status?: string;
+  };
+}
+
+export async function enhanceContactMessage(message: string): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('Gemini API key is not configured.');
+  }
+
+  const trimmedMessage = message.trim();
+
+  if (!trimmedMessage) {
+    throw new Error('Message is empty.');
+  }
+
+  const response = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      system_instruction: {
+        role: 'system',
+        parts: [
+          {
+            text: [
+              'You are a writing assistant helping to polish messages for a professional portfolio contact form.',
+              'Improve clarity, grammar, and tone while preserving the original intent.',
+              'Respond with plain text only, without additional commentary or formatting.',
+              'Keep the response under 500 words.',
+            ].join(' '),
+          },
+        ],
+      },
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text: [
+                'Rewrite the following message so it reads professionally while maintaining the author\'s intent.',
+                'Return only the improved message.',
+                `Message:\n${trimmedMessage}`,
+              ].join('\n\n'),
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.4,
+        topP: 0.95,
+        topK: 32,
+        maxOutputTokens: 1024,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to contact Gemini API.');
+  }
+
+  const payload = (await response.json()) as GenerateContentResponse;
+
+  if (payload.error) {
+    throw new Error(payload.error.message || 'Gemini API returned an error.');
+  }
+
+  if (payload.promptFeedback?.blockReason) {
+    throw new Error('Gemini could not process the request.');
+  }
+
+  const text = payload.candidates
+    ?.flatMap((candidate) => candidate.content?.parts ?? [])
+    .map((part) => part.text ?? '')
+    .join('')
+    .trim();
+
+  if (!text) {
+    throw new Error('Gemini did not return an enhanced message.');
+  }
+
+  return text;
+}


### PR DESCRIPTION
## Summary
- add a Gemini-backed API route for improving contact form messages
- wire the contact form to call the enhancement endpoint and update the editor content with the response

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_69004ff1acd08327a29abdc71bb6c597