### PR TITLE
Add split resume button with view option

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowDownRight, Github, Linkedin, Mail } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ResumeButton } from "@/components/resume-button";
 
 const socialLinks = [
   {
@@ -48,22 +49,7 @@ export default function HeroSection() {
                 <ArrowDownRight className="h-5 w-5" aria-hidden />
               </Link>
             </Button>
-            <Button
-              asChild
-              size="lg"
-              variant="outline"
-              className="px-6"
-            >
-              <a
-                href="/assets/resume.pdf"
-                download
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Download Sam Antholem Manalo's resume"
-              >
-                Download Resume
-              </a>
-            </Button>
+            <ResumeButton />
           </div>
 
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/resume-button.tsx
+++ b/src/components/resume-button.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const RESUME_URL = "/assets/resume.pdf";
+
+export function ResumeButton() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        event.target instanceof Node &&
+        !containerRef.current.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative inline-flex items-stretch">
+      <Button
+        asChild
+        size="lg"
+        variant="outline"
+        className="rounded-r-none"
+        aria-label="Download Sam Antholem Manalo's resume"
+      >
+        <a href={RESUME_URL} download>
+          Download Resume
+        </a>
+      </Button>
+      <Button
+        type="button"
+        size="lg"
+        variant="outline"
+        className="rounded-l-none border-l-0 px-2"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span className="sr-only">Open resume options</span>
+        <ChevronDown className="h-4 w-4" aria-hidden />
+      </Button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-10 mt-2 w-40 overflow-hidden rounded-md border bg-background text-sm shadow-lg"
+        >
+          <Link
+            href={RESUME_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="block px-3 py-2 transition hover:bg-muted"
+            onClick={() => setOpen(false)}
+          >
+            View Resume
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side ResumeButton component that provides both download and view options for the resume
- replace the hero section resume link with the enhanced split button

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ecccbcf888327a3a4c8f411ff8b4b)