### PR TITLE
Add AI chat assistant to navbar

### DIFF
--- a/src/components/ui/chat-assistant.tsx
+++ b/src/components/ui/chat-assistant.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { FormEvent, useEffect, useRef, useState } from "react"
+import { MessageCircle, Send } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { chatIntroMessage, generateChatResponse, suggestedPrompts } from "@/lib/chatbot"
+import { cn } from "@/lib/utils"
+
+type ChatMessage = {
+  id: number
+  role: "user" | "assistant"
+  content: string
+}
+
+export default function ChatAssistant() {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { id: 0, role: "assistant", content: chatIntroMessage },
+  ])
+  const [inputValue, setInputValue] = useState("")
+  const viewportRef = useRef<HTMLDivElement | null>(null)
+  const messageIdRef = useRef(0)
+
+  useEffect(() => {
+    viewportRef.current?.scrollTo({
+      top: viewportRef.current.scrollHeight,
+      behavior: "smooth",
+    })
+  }, [messages])
+
+  const getNextId = () => {
+    messageIdRef.current += 1
+    return messageIdRef.current
+  }
+
+  const sendPrompt = (prompt: string) => {
+    const normalizedPrompt = prompt.trim()
+
+    if (!normalizedPrompt) {
+      return
+    }
+
+    const userMessage: ChatMessage = {
+      id: getNextId(),
+      role: "user",
+      content: normalizedPrompt,
+    }
+
+    const assistantMessage: ChatMessage = {
+      id: getNextId(),
+      role: "assistant",
+      content: generateChatResponse(normalizedPrompt),
+    }
+
+    setMessages((previous) => [...previous, userMessage, assistantMessage])
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmed = inputValue.trim()
+    if (!trimmed) {
+      return
+    }
+
+    sendPrompt(trimmed)
+    setInputValue("")
+  }
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label="Open AI chat assistant"
+        >
+          <MessageCircle className="h-5 w-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex h-full w-full max-w-lg flex-col p-0">
+        <SheetHeader className="border-b px-6 py-5 text-left">
+          <SheetTitle className="text-lg">Portfolio AI Guide</SheetTitle>
+          <SheetDescription className="text-sm">
+            Ask about Sam's background, skills, featured work, or how to connect.
+          </SheetDescription>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {suggestedPrompts.map((prompt) => (
+              <button
+                key={prompt}
+                type="button"
+                onClick={() => sendPrompt(prompt)}
+                className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition hover:bg-primary/20"
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        </SheetHeader>
+        <div ref={viewportRef} className="flex-1 space-y-4 overflow-y-auto px-6 py-5">
+          {messages.map((message) => (
+            <div
+              key={message.id}
+              className={cn("flex", message.role === "user" ? "justify-end" : "justify-start")}
+            >
+              <div
+                className={cn(
+                  "max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed",
+                  message.role === "assistant"
+                    ? "bg-muted text-foreground"
+                    : "bg-primary text-primary-foreground shadow-sm"
+                )}
+              >
+                <p className="whitespace-pre-line">{message.content}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <form onSubmit={handleSubmit} className="border-t px-6 py-4">
+          <div className="flex items-end gap-2">
+            <label className="sr-only" htmlFor="chat-input">
+              Ask the AI assistant
+            </label>
+            <textarea
+              id="chat-input"
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder="Ask anything about Sam..."
+              rows={2}
+              className="h-20 w-full resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+            <Button type="submit" size="icon" disabled={!inputValue.trim()} aria-label="Send message">
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -15,6 +15,7 @@ import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useThemeStore } from "@/lib/theme-store"
 import { Separator } from "@/components/ui/separator"
+import ChatAssistant from "@/components/ui/chat-assistant"
 
 const links = [
     { href: "#about", label: "About" },
@@ -98,6 +99,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                 </nav>
 
                 <div className="flex items-center gap-2">
+                    <ChatAssistant />
                     <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
                         {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                     </Button>

--- a/src/lib/chatbot.ts
+++ b/src/lib/chatbot.ts
@@ -1,0 +1,86 @@
+export const chatIntroMessage =
+  "Hello! I'm Sam's AI portfolio guide. Ask me about his background, skills, services, featured projects, or how to get in touch. I can also point you to his resume.";
+
+const resumeUrl = "/assets/resume.pdf";
+
+const topicResponses: { keywords: string[]; response: string }[] = [
+  {
+    keywords: [
+      "about",
+      "background",
+      "experience",
+      "bio",
+      "career",
+      "history",
+      "story",
+    ],
+    response:
+      "Sam Antholem Manalo is a principal software engineer based in Clark, Pampanga, Philippines. He partners with founders and product leaders to translate ambitious ideas into resilient, human-centered software that balances accessibility, systems thinking, and AI-accelerated workflows. Over nine years, he has led distributed teams, modernized platforms, and shipped data-informed experiences across finance, commerce, and SaaS domains.",
+  },
+  {
+    keywords: ["highlight", "focus", "strength", "approach", "specialty"],
+    response:
+      "Core focus areas include principal engineering leadership, evolving platforms and design systems, crafting experience strategies, and blending automation with human insight to deliver confident, measurable outcomes.",
+  },
+  {
+    keywords: ["skill", "stack", "technology", "tool", "capability", "competence"],
+    response:
+      "Sam's toolkit spans front-end engineering (React, Next.js, Tailwind, Chakra UI, Material UI, Shadcn), backend and APIs (Node.js, Express, PHP, Python, Java), data platforms (MongoDB, MySQL, PostgreSQL, Firebase, Supabase), and DevOps delivery (Docker, Vercel, GitHub, GitLab). He also collaborates through design tooling like Figma and Adobe XD, and explores AI platforms including Hugging Face and Google Gemini.",
+  },
+  {
+    keywords: ["service", "offer", "engagement", "help", "partner"],
+    response:
+      "He offers design systems and experience design, full-stack web engineering, and AI-assisted product enablement. Engagements cover component libraries and accessibility audits, Next.js and API development, performance tuning, workflow automation, and ethical AI guidance tailored to different stages of product growth.",
+  },
+  {
+    keywords: ["project", "work", "portfolio", "case"],
+    response:
+      "Featured work includes the Atlas Insights Dashboard (a real-time marketing analytics platform built with Next.js, TypeScript, and Tailwind CSS), the Aurora Commerce Platform (a headless commerce experience powered by Next.js, Shopify, and GraphQL), and the Horizon Studio Portfolio (a cinematic creative showcase built with Next.js, Contentful, and Framer Motion).",
+  },
+  {
+    keywords: ["resume", "cv", "curriculum", "download"],
+    response:
+      `You can view or download Sam's resume anytime at ${resumeUrl}. The hero section also includes quick access if you'd like to grab a copy for later.`,
+  },
+  {
+    keywords: ["contact", "email", "phone", "reach", "connect", "call"],
+    response:
+      "You can connect with Sam at antholemlemmanalo@gmail.com or by phone at +63 977 333 6944. There is also a contact form on the site if you'd like to share details about a collaboration.",
+  },
+  {
+    keywords: ["location", "based", "where", "city"],
+    response: "Sam is currently based in Clark and Mabalacat, Pampanga in the Philippines.",
+  },
+  {
+    keywords: ["social", "github", "linkedin", "profile"],
+    response:
+      "You can explore more through his GitHub (https://github.com/antholem) and LinkedIn (https://www.linkedin.com/in/antholem). Those links are also available in the hero section for quick access.",
+  },
+];
+
+const greetingKeywords = ["hello", "hi", "hey", "greetings", "good morning", "good afternoon", "good evening"];
+
+export function generateChatResponse(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (greetingKeywords.some((keyword) => normalized.includes(keyword))) {
+    return "Hi there! I'm ready to share anything about Sam's experience, expertise, services, projects, or contact details.";
+  }
+
+  const responses = topicResponses
+    .filter((topic) => topic.keywords.some((keyword) => normalized.includes(keyword)))
+    .map((topic) => topic.response);
+
+  if (responses.length > 0) {
+    return responses.join("\n\n");
+  }
+
+  return "I can help with questions about Sam's background, skills, services, projects, ways to get in touch, and even provide his resume. What would you like to know?";
+}
+
+export const suggestedPrompts = [
+  "What are Sam's core skills?",
+  "Can I see Sam's resume?",
+  "Tell me about Sam's featured projects.",
+  "How can I contact Sam?",
+];


### PR DESCRIPTION
## Summary
- add a chat assistant icon to the navbar that opens a dedicated portfolio AI guide
- implement a reusable chat assistant component with scrolling history and suggested prompts
- centralize portfolio knowledge in a lightweight generator used to craft assistant replies

## Testing
- npm run lint *(fails: requires @eslint/eslintrc package in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690efd0fc16c8327be6ee561e056ac64)