### PR TITLE
Add chat assistant widget to navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-icons": "^5.5.0",
+    "react-markdown": "^9.0.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "remark-gfm": "^4.0.0",
     "zustand": "^5.0.8",
     "sonner": "^1.5.4"
   },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server"
+
+const MODEL_NAME = process.env.GEMINI_MODEL ?? "gemini-2.0-flash"
+const GENERATE_CONTENT_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL_NAME}:generateContent`
+
+type ChatRole = "user" | "assistant"
+
+type ChatMessage = {
+    role: ChatRole
+    content: string
+}
+
+type GeminiPart = {
+    text?: string
+}
+
+type GeminiContent = {
+    role: "user" | "model" | "system"
+    parts: GeminiPart[]
+}
+
+type GeminiCandidate = {
+    content?: {
+        parts?: GeminiPart[]
+    }
+}
+
+type GeminiResponse = {
+    candidates?: GeminiCandidate[]
+    promptFeedback?: {
+        blockReason?: string
+    }
+    error?: {
+        message?: string
+    }
+}
+
+type ChatRequestBody = {
+    messages?: ChatMessage[]
+}
+
+const buildContents = (messages: ChatMessage[]): GeminiContent[] =>
+    messages.map((message) => ({
+        role: message.role === "assistant" ? "model" : "user",
+        parts: [{ text: message.content }],
+    }))
+
+const extractReply = (payload: GeminiResponse): string | null => {
+    if (!payload.candidates?.length) {
+        return null
+    }
+
+    const [candidate] = payload.candidates
+    const parts = candidate.content?.parts
+
+    if (!parts?.length) {
+        return null
+    }
+
+    return parts
+        .map((part) => (typeof part.text === "string" ? part.text : ""))
+        .join("")
+        .trim()
+}
+
+const sanitizeMessages = (messages: ChatMessage[] | undefined): ChatMessage[] => {
+    if (!messages) {
+        return []
+    }
+
+    return messages
+        .map((message) => ({
+            role: message.role === "assistant" ? "assistant" : "user",
+            content: message.content?.trim() ?? "",
+        }))
+        .filter((message): message is ChatMessage => Boolean(message.content))
+}
+
+export async function POST(request: Request) {
+    const apiKey = process.env.GEMINI_API_KEY
+
+    if (!apiKey) {
+        return NextResponse.json(
+            { error: "Gemini API key is not configured." },
+            { status: 500 }
+        )
+    }
+
+    let body: ChatRequestBody
+
+    try {
+        body = (await request.json()) as ChatRequestBody
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON payload." }, { status: 400 })
+    }
+
+    const messages = sanitizeMessages(body.messages)
+
+    if (!messages.length) {
+        return NextResponse.json(
+            { error: "At least one message is required to continue the conversation." },
+            { status: 400 }
+        )
+    }
+
+    const contents = buildContents(messages)
+
+    try {
+        const response = await fetch(`${GENERATE_CONTENT_ENDPOINT}?key=${apiKey}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                contents,
+                systemInstruction: {
+                    role: "system",
+                    parts: [
+                        {
+                            text: [
+                                "You are a helpful AI assistant embedded inside a personal portfolio website.",
+                                "Answer each question clearly and concisely using Markdown when it improves readability.",
+                                "If you do not know the answer, be honest and offer helpful suggestions for finding it.",
+                                "Keep responses welcoming and professional, and avoid fabricating details about the user.",
+                            ].join("\n"),
+                        },
+                    ],
+                },
+                generationConfig: {
+                    temperature: 0.7,
+                    topP: 0.95,
+                    topK: 40,
+                    maxOutputTokens: 512,
+                },
+            }),
+        })
+
+        if (!response.ok) {
+            let errorPayload: GeminiResponse | undefined
+
+            try {
+                errorPayload = (await response.json()) as GeminiResponse
+            } catch {
+                // ignore JSON parsing errors
+            }
+
+            const errorMessage =
+                errorPayload?.error?.message ??
+                errorPayload?.promptFeedback?.blockReason ??
+                `Gemini API returned status ${response.status}.`
+
+            return NextResponse.json({ error: errorMessage }, { status: response.status })
+        }
+
+        const payload = (await response.json()) as GeminiResponse
+        const reply = extractReply(payload)
+
+        if (!reply) {
+            return NextResponse.json(
+                { error: "The assistant responded with an empty message. Please try again." },
+                { status: 502 }
+            )
+        }
+
+        return NextResponse.json({ reply })
+    } catch (error) {
+        const message =
+            error instanceof Error && error.message
+                ? error.message
+                : "Unexpected error while contacting Gemini API."
+
+        return NextResponse.json({ error: message }, { status: 500 })
+    }
+}

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -97,9 +97,9 @@ export function ChatWidget() {
     }
 
     return (
-        <div className="flex h-full min-h-0 flex-1 flex-col">
-            <div className="flex items-center justify-center border-b bg-muted/60 px-4 py-3">
-                <p className="text-sm font-semibold">Chat Assistant</p>
+        <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="sticky top-0 z-10 flex items-center justify-center border-b bg-background/95 px-4 py-3 text-sm font-semibold backdrop-blur">
+                Chat Assistant
             </div>
             <div className="flex h-full flex-col">
                 <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm">

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -294,7 +294,7 @@ export function ChatWidget() {
     }
 
     return (
-        <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex h-full min-h-0 flex-1 flex-col">
             <div
                 className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur"
                 style={{ paddingTop: "env(safe-area-inset-top)" }}
@@ -314,8 +314,8 @@ export function ChatWidget() {
                     </SheetClose>
                 </div>
             </div>
-            <div className="flex h-full flex-col">
-                <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm">
+            <div className="flex h-full min-h-0 flex-col">
+                <div className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm">
                     {messages.map((message) => (
                         <div
                             key={message.id}

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -2,8 +2,9 @@
 
 import { FormEvent, useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { SheetClose } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
-import { SendHorizontal } from "lucide-react"
+import { SendHorizontal, X } from "lucide-react"
 
 type Message = {
     id: number
@@ -98,8 +99,21 @@ export function ChatWidget() {
 
     return (
         <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-            <div className="sticky top-0 z-10 flex items-center justify-center border-b bg-background/95 px-4 py-3 text-sm font-semibold backdrop-blur">
-                Chat Assistant
+            <div className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
+                <div className="relative flex items-center justify-center px-4 py-3 text-sm font-semibold">
+                    <span>Chat Assistant</span>
+                    <SheetClose asChild>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="absolute right-2.5 top-2.5"
+                            aria-label="Close chat assistant"
+                        >
+                            <X className="h-4 w-4" />
+                        </Button>
+                    </SheetClose>
+                </div>
             </div>
             <div className="flex h-full flex-col">
                 <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm">

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -97,7 +97,7 @@ export function ChatWidget() {
     }
 
     return (
-        <div className="flex h-full flex-col">
+        <div className="flex h-full min-h-0 flex-1 flex-col">
             <div className="flex items-center justify-center border-b bg-muted/60 px-4 py-3">
                 <p className="text-sm font-semibold">Chat Assistant</p>
             </div>
@@ -134,7 +134,7 @@ export function ChatWidget() {
                 </div>
                 <form
                     onSubmit={handleSubmit}
-                    className="flex items-center gap-2 border-t px-3 py-3"
+                    className="flex items-center gap-2 border-t px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
                 >
                     <input
                         value={inputValue}

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { FormEvent, useEffect, useRef, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { SendHorizontal, X } from "lucide-react"
+
+type Message = {
+    id: number
+    sender: "user" | "bot"
+    text: string
+}
+
+const initialBotMessage: Message = {
+    id: 0,
+    sender: "bot",
+    text: "Hi there! I'm your friendly assistant. How can I help you today?",
+}
+
+function createBotResponse(userMessage: string): string {
+    return `You said: "${userMessage}". I'm just a demo bot, but I'm here to keep you company!`
+}
+
+export function ChatWidget({ onClose }: { onClose: () => void }) {
+    const [messages, setMessages] = useState<Message[]>([initialBotMessage])
+    const [inputValue, setInputValue] = useState("")
+    const [isResponding, setIsResponding] = useState(false)
+    const endRef = useRef<HTMLDivElement | null>(null)
+
+    useEffect(() => {
+        endRef.current?.scrollIntoView({ behavior: "smooth" })
+    }, [messages])
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        const trimmed = inputValue.trim()
+        if (!trimmed) return
+
+        const timestamp = Date.now()
+        setMessages((prev) => [
+            ...prev,
+            { id: timestamp, sender: "user", text: trimmed },
+        ])
+        setInputValue("")
+        setIsResponding(true)
+
+        setTimeout(() => {
+            setMessages((prev) => [
+                ...prev,
+                {
+                    id: timestamp + 1,
+                    sender: "bot",
+                    text: createBotResponse(trimmed),
+                },
+            ])
+            setIsResponding(false)
+        }, 450)
+    }
+
+    return (
+        <div className="fixed bottom-4 right-4 z-50 w-[calc(100vw-2rem)] max-w-sm overflow-hidden rounded-xl border bg-background shadow-xl">
+            <div className="flex items-center justify-between border-b bg-muted/60 px-4 py-3">
+                <p className="text-sm font-semibold">Chat Assistant</p>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    aria-label="Close chat"
+                    onClick={onClose}
+                >
+                    <X className="h-4 w-4" />
+                </Button>
+            </div>
+            <div className="flex max-h-96 flex-col">
+                <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm">
+                    {messages.map((message) => (
+                        <div
+                            key={message.id}
+                            className={cn(
+                                "flex",
+                                message.sender === "user"
+                                    ? "justify-end"
+                                    : "justify-start"
+                            )}
+                        >
+                            <div
+                                className={cn(
+                                    "max-w-[80%] rounded-lg px-3 py-2",
+                                    message.sender === "user"
+                                        ? "bg-primary text-primary-foreground"
+                                        : "bg-muted text-muted-foreground"
+                                )}
+                            >
+                                {message.text}
+                            </div>
+                        </div>
+                    ))}
+                    {isResponding ? (
+                        <div className="text-xs text-muted-foreground">
+                            The assistant is typing...
+                        </div>
+                    ) : null}
+                    <div ref={endRef} />
+                </div>
+                <form
+                    onSubmit={handleSubmit}
+                    className="flex items-center gap-2 border-t px-3 py-3"
+                >
+                    <input
+                        value={inputValue}
+                        onChange={(event) => setInputValue(event.target.value)}
+                        placeholder="Type your message..."
+                        className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    />
+                    <Button type="submit" size="icon" disabled={isResponding}>
+                        <SendHorizontal className="h-4 w-4" />
+                    </Button>
+                </form>
+            </div>
+        </div>
+    )
+}

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -107,7 +107,7 @@ export function ChatWidget() {
                             type="button"
                             variant="ghost"
                             size="icon"
-                            className="absolute right-2.5 top-2.5"
+                            className="absolute right-2.5 top-1/2 -translate-y-1/2"
                             aria-label="Close chat assistant"
                         >
                             <X className="h-4 w-4" />

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { SheetClose } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
 import { SendHorizontal, X } from "lucide-react"
 
@@ -21,7 +22,7 @@ function createBotResponse(userMessage: string): string {
     return `You said: "${userMessage}". I'm just a demo bot, but I'm here to keep you company!`
 }
 
-export function ChatWidget({ onClose }: { onClose: () => void }) {
+export function ChatWidget() {
     const [messages, setMessages] = useState<Message[]>([initialBotMessage])
     const [inputValue, setInputValue] = useState("")
     const [isResponding, setIsResponding] = useState(false)
@@ -58,21 +59,22 @@ export function ChatWidget({ onClose }: { onClose: () => void }) {
     }
 
     return (
-        <div className="fixed bottom-4 right-4 z-50 w-[calc(100vw-2rem)] max-w-sm overflow-hidden rounded-xl border bg-background shadow-xl">
+        <div className="flex h-full flex-col">
             <div className="flex items-center justify-between border-b bg-muted/60 px-4 py-3">
                 <p className="text-sm font-semibold">Chat Assistant</p>
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8"
-                    aria-label="Close chat"
-                    onClick={onClose}
-                >
-                    <X className="h-4 w-4" />
-                </Button>
+                <SheetClose asChild>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label="Close chat"
+                    >
+                        <X className="h-4 w-4" />
+                    </Button>
+                </SheetClose>
             </div>
-            <div className="flex max-h-96 flex-col">
+            <div className="flex h-full flex-col">
                 <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm">
                     {messages.map((message) => (
                         <div

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -112,7 +112,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                         </SheetTrigger>
                         <SheetContent
                             side="right"
-                            className="flex h-full w-full max-w-md flex-col gap-0 overflow-hidden p-0 [&>button[data-radix-dialog-close]]:hidden"
+                            className="flex h-[100dvh] w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:h-full sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden"
                             style={{
                                 height: "100dvh",
                                 maxHeight: "100dvh",

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -114,6 +114,12 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                             side="right"
                             className="flex h-full w-full max-w-md flex-col gap-0 p-0"
                         >
+                            <SheetTitle className="sr-only">
+                                Chat Assistant
+                            </SheetTitle>
+                            <SheetDescription className="sr-only">
+                                Start a conversation with the portfolio assistant
+                            </SheetDescription>
                             <ChatWidget />
                         </SheetContent>
                     </Sheet>

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -111,6 +111,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                             </Button>
                         </SheetTrigger>
                         <SheetContent
+                            forceMount
                             side="right"
                             className="flex h-[100dvh] w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:h-full sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden"
                             style={{

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -1,21 +1,22 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import { Button } from "@/components/ui/button"
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import {
     Sheet,
     SheetTrigger,
     SheetContent,
     SheetTitle,
     SheetDescription,
-} from "@/components/ui/sheet"
-import { Menu, MessageCircle } from "lucide-react"
-import { FaMoon, FaSun } from "react-icons/fa"
-import Image from "next/image"
-import { useEffect, useState } from "react"
-import { useThemeStore } from "@/lib/theme-store"
-import { Separator } from "@/components/ui/separator"
-import { ChatWidget } from "@/components/ui/chat-widget"
+} from "@/components/ui/sheet";
+import { Menu, MessageCircle } from "lucide-react";
+import { FaMoon, FaSun } from "react-icons/fa";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { useThemeStore } from "@/lib/theme-store";
+import { Separator } from "@/components/ui/separator";
+import { ChatWidget } from "@/components/ui/chat-widget";
+import { useChatStore } from "@/lib/chat-store";
 
 const links = [
     { href: "#about", label: "About" },
@@ -23,26 +24,31 @@ const links = [
     { href: "#services", label: "Services" },
     { href: "#projects", label: "Projects" },
     { href: "#contact", label: "Contacts" },
-]
+];
 
-export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dark" }) {
-    const theme = useThemeStore((state) => state.theme)
-    const setTheme = useThemeStore((state) => state.setTheme)
-    const toggleTheme = useThemeStore((state) => state.toggleTheme)
-    const [mounted, setMounted] = useState(false)
+export default function Navbar({
+    initialTheme,
+}: {
+    initialTheme?: "light" | "dark";
+}) {
+    const theme = useThemeStore((state) => state.theme);
+    const setTheme = useThemeStore((state) => state.setTheme);
+    const toggleTheme = useThemeStore((state) => state.toggleTheme);
+    const { hasUnread, setHasUnread } = useChatStore();
+    const [mounted, setMounted] = useState(false);
+    const [isChatOpen, setIsChatOpen] = useState(false);
 
     useEffect(() => {
-        if (initialTheme) {
-            setTheme(initialTheme)
-        }
-        setMounted(true)
-    }, [initialTheme, setTheme])
+        if (initialTheme) setTheme(initialTheme);
+        setMounted(true);
+    }, [initialTheme, setTheme]);
 
-    const currentTheme = mounted ? theme : initialTheme || theme
+    const currentTheme = mounted ? theme : initialTheme || theme;
 
     return (
         <header className="sticky top-0 z-40 w-full bg-card backdrop-blur">
             <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+                {/* Mobile Menu */}
                 <div className="md:hidden">
                     <Sheet>
                         <SheetTrigger asChild>
@@ -71,6 +77,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                     </Sheet>
                 </div>
 
+                {/* Logo */}
                 <Link href="/" className="flex items-center gap-2 font-semibold">
                     <div className="relative h-6 w-6">
                         <Image
@@ -99,17 +106,27 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                 </nav>
 
                 <div className="flex items-center gap-2">
-                    <Sheet>
+                    <Sheet
+                        modal={false}
+                        onOpenChange={(open) => {
+                            setIsChatOpen(open);
+                            if (open) setHasUnread(false);
+                        }}
+                    >
                         <SheetTrigger asChild>
                             <Button
                                 variant="ghost"
                                 size="icon"
-                                className="size-8"
+                                className="relative size-8"
                                 aria-label="Open chat assistant"
                             >
                                 <MessageCircle className="h-5 w-5" />
+                                {hasUnread && !isChatOpen && (
+                                    <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary shadow-[0_0_8px_2px_rgba(var(--primary-rgb),0.5)]" />
+                                )}
                             </Button>
                         </SheetTrigger>
+
                         <SheetContent
                             forceMount
                             side="right"
@@ -120,21 +137,28 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                                 minHeight: "100svh",
                             }}
                         >
-                            <SheetTitle className="sr-only">
-                                Chat Assistant
-                            </SheetTitle>
+                            <SheetTitle className="sr-only">Chat Assistant</SheetTitle>
                             <SheetDescription className="sr-only">
                                 Start a conversation with the portfolio assistant
                             </SheetDescription>
-                            <ChatWidget />
+
+                            <div className="absolute inset-0">
+                                <ChatWidget />
+                            </div>
                         </SheetContent>
                     </Sheet>
-                    <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
+
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        onClick={toggleTheme}
+                    >
                         {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                     </Button>
                 </div>
             </div>
             <Separator />
         </header>
-    )
+    );
 }

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -9,12 +9,13 @@ import {
     SheetTitle,
     SheetDescription,
 } from "@/components/ui/sheet"
-import { Menu } from "lucide-react"
+import { Menu, MessageCircle } from "lucide-react"
 import { FaMoon, FaSun } from "react-icons/fa"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useThemeStore } from "@/lib/theme-store"
 import { Separator } from "@/components/ui/separator"
+import { ChatWidget } from "@/components/ui/chat-widget"
 
 const links = [
     { href: "#about", label: "About" },
@@ -29,6 +30,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
     const setTheme = useThemeStore((state) => state.setTheme)
     const toggleTheme = useThemeStore((state) => state.toggleTheme)
     const [mounted, setMounted] = useState(false)
+    const [isChatOpen, setIsChatOpen] = useState(false)
 
     useEffect(() => {
         if (initialTheme) {
@@ -98,12 +100,22 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                 </nav>
 
                 <div className="flex items-center gap-2">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label="Open chat assistant"
+                        onClick={() => setIsChatOpen((prev) => !prev)}
+                    >
+                        <MessageCircle className="h-5 w-5" />
+                    </Button>
                     <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
                         {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                     </Button>
                 </div>
             </div>
             <Separator />
+            {isChatOpen ? <ChatWidget onClose={() => setIsChatOpen(false)} /> : null}
         </header>
     )
 }

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -30,7 +30,6 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
     const setTheme = useThemeStore((state) => state.setTheme)
     const toggleTheme = useThemeStore((state) => state.toggleTheme)
     const [mounted, setMounted] = useState(false)
-    const [isChatOpen, setIsChatOpen] = useState(false)
 
     useEffect(() => {
         if (initialTheme) {
@@ -100,22 +99,30 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                 </nav>
 
                 <div className="flex items-center gap-2">
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8"
-                        aria-label="Open chat assistant"
-                        onClick={() => setIsChatOpen((prev) => !prev)}
-                    >
-                        <MessageCircle className="h-5 w-5" />
-                    </Button>
+                    <Sheet>
+                        <SheetTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="size-8"
+                                aria-label="Open chat assistant"
+                            >
+                                <MessageCircle className="h-5 w-5" />
+                            </Button>
+                        </SheetTrigger>
+                        <SheetContent
+                            side="right"
+                            className="flex h-full w-full max-w-md flex-col gap-0 p-0"
+                        >
+                            <ChatWidget />
+                        </SheetContent>
+                    </Sheet>
                     <Button variant="ghost" size="icon" className="size-8" onClick={toggleTheme}>
                         {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
                     </Button>
                 </div>
             </div>
             <Separator />
-            {isChatOpen ? <ChatWidget onClose={() => setIsChatOpen(false)} /> : null}
         </header>
     )
 }

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -112,7 +112,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                         </SheetTrigger>
                         <SheetContent
                             side="right"
-                            className="flex h-full w-full max-w-md flex-col gap-0 p-0"
+                            className="flex h-dvh min-h-[100svh] w-full max-w-md flex-col gap-0 p-0 md:h-screen"
                         >
                             <SheetTitle className="sr-only">
                                 Chat Assistant

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -112,7 +112,7 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                         </SheetTrigger>
                         <SheetContent
                             side="right"
-                            className="flex h-full w-full max-w-md flex-col gap-0 overflow-hidden p-0"
+                            className="flex h-full w-full max-w-md flex-col gap-0 overflow-hidden p-0 [&>button[data-radix-dialog-close]]:hidden"
                             style={{
                                 height: "100dvh",
                                 maxHeight: "100dvh",

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -112,7 +112,12 @@ export default function Navbar({ initialTheme }: { initialTheme?: "light" | "dar
                         </SheetTrigger>
                         <SheetContent
                             side="right"
-                            className="flex h-dvh min-h-[100svh] w-full max-w-md flex-col gap-0 p-0 md:h-screen"
+                            className="flex h-full w-full max-w-md flex-col gap-0 overflow-hidden p-0"
+                            style={{
+                                height: "100dvh",
+                                maxHeight: "100dvh",
+                                minHeight: "100svh",
+                            }}
                         >
                             <SheetTitle className="sr-only">
                                 Chat Assistant

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -1,30 +1,39 @@
-import { create } from "zustand"
+import { create } from "zustand";
 
 export type Message = {
-    id: number
-    sender: "user" | "bot"
-    text: string
-}
+    id: number;
+    sender: "user" | "bot";
+    text: string;
+};
 
 type ChatState = {
-    messages: Message[]
-    setMessages: (messages: Message[]) => void
-    addMessage: (message: Message) => void
-    resetMessages: () => void
-}
+    messages: Message[];
+    isResponding: boolean;
+    hasUnread: boolean;
+    setMessages: (messages: Message[]) => void;
+    addMessage: (message: Message) => void;
+    setIsResponding: (state: boolean) => void;
+    setHasUnread: (state: boolean) => void;
+    resetMessages: () => void;
+};
 
 const initialMessage: Message = {
     id: 0,
     sender: "bot",
     text: "Hi there! I'm your friendly assistant. How can I help you today?",
-}
+};
 
 export const useChatStore = create<ChatState>((set) => ({
     messages: [initialMessage],
+    isResponding: false,
+    hasUnread: false,
     setMessages: (messages) => set({ messages }),
     addMessage: (message) =>
         set((state) => ({
             messages: [...state.messages, message],
+            hasUnread: message.sender === "bot" ? true : state.hasUnread,
         })),
-    resetMessages: () => set({ messages: [initialMessage] }),
-}))
+    setIsResponding: (state) => set({ isResponding: state }),
+    setHasUnread: (state) => set({ hasUnread: state }),
+    resetMessages: () => set({ messages: [initialMessage], hasUnread: false }),
+}));

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand"
+
+export type ChatMessage = {
+    id: number
+    sender: "user" | "bot"
+    text: string
+}
+
+type ChatStore = {
+    messages: ChatMessage[]
+    setMessages: (messages: ChatMessage[]) => void
+    addMessage: (message: ChatMessage) => void
+    reset: () => void
+}
+
+const initialBotMessage: ChatMessage = {
+    id: 0,
+    sender: "bot",
+    text: "Hi there! I'm your friendly assistant. How can I help you today?",
+}
+
+export const useChatStore = create<ChatStore>((set) => ({
+    messages: [initialBotMessage],
+    setMessages: (messages) =>
+        set({
+            messages: messages.reduce<ChatMessage[]>((accumulator, message) => {
+                if (!accumulator.some((item) => item.id === message.id)) {
+                    accumulator.push(message)
+                }
+
+                return accumulator
+            }, []),
+        }),
+    addMessage: (message) =>
+        set((state) => {
+            const alreadyExists = state.messages.some((item) => item.id === message.id)
+
+            if (alreadyExists) {
+                return state
+            }
+
+            return { messages: [...state.messages, message] }
+        }),
+    reset: () => set({ messages: [initialBotMessage] }),
+}))

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -1,45 +1,30 @@
 import { create } from "zustand"
 
-export type ChatMessage = {
+export type Message = {
     id: number
     sender: "user" | "bot"
     text: string
 }
 
-type ChatStore = {
-    messages: ChatMessage[]
-    setMessages: (messages: ChatMessage[]) => void
-    addMessage: (message: ChatMessage) => void
-    reset: () => void
+type ChatState = {
+    messages: Message[]
+    setMessages: (messages: Message[]) => void
+    addMessage: (message: Message) => void
+    resetMessages: () => void
 }
 
-const initialBotMessage: ChatMessage = {
+const initialMessage: Message = {
     id: 0,
     sender: "bot",
     text: "Hi there! I'm your friendly assistant. How can I help you today?",
 }
 
-export const useChatStore = create<ChatStore>((set) => ({
-    messages: [initialBotMessage],
-    setMessages: (messages) =>
-        set({
-            messages: messages.reduce<ChatMessage[]>((accumulator, message) => {
-                if (!accumulator.some((item) => item.id === message.id)) {
-                    accumulator.push(message)
-                }
-
-                return accumulator
-            }, []),
-        }),
+export const useChatStore = create<ChatState>((set) => ({
+    messages: [initialMessage],
+    setMessages: (messages) => set({ messages }),
     addMessage: (message) =>
-        set((state) => {
-            const alreadyExists = state.messages.some((item) => item.id === message.id)
-
-            if (alreadyExists) {
-                return state
-            }
-
-            return { messages: [...state.messages, message] }
-        }),
-    reset: () => set({ messages: [initialBotMessage] }),
+        set((state) => ({
+            messages: [...state.messages, message],
+        })),
+    resetMessages: () => set({ messages: [initialMessage] }),
 }))


### PR DESCRIPTION
## Summary
- add a chat assistant widget that opens from the navbar and supports simple bot replies
- place a chat icon next to the existing dark/light mode toggle

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105438b5e08327ace6d437bb2e5f40)