### PR TITLE
Improve chat UI styling and notification behavior

### DIFF
--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-    FormEvent,
-    useEffect,
-    useRef,
-    useState,
-    type HTMLAttributes,
-} from "react";
+import { FormEvent, useEffect, useRef, type HTMLAttributes } from "react";
 import { Button } from "@/components/ui/button";
 import { SheetClose } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
@@ -51,8 +45,8 @@ const markdownComponents: Components = {
 };
 
 export function ChatWidget() {
-    const { messages, addMessage, isResponding, setIsResponding } = useChatStore();
-    const [inputValue, setInputValue] = useState("");
+    const { messages, addMessage, isResponding, setIsResponding, inputDraft, setInputDraft } =
+        useChatStore();
     const endRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
@@ -62,13 +56,13 @@ export function ChatWidget() {
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         if (isResponding) return;
-        const trimmed = inputValue.trim();
+        const trimmed = inputDraft.trim();
         if (!trimmed) return;
 
         const timestamp = Date.now();
         const userMessage = { id: timestamp, sender: "user" as const, text: trimmed };
         addMessage(userMessage);
-        setInputValue("");
+        setInputDraft("");
         setIsResponding(true);
 
         fetch("/api/chat", {
@@ -173,8 +167,8 @@ export function ChatWidget() {
                     className="flex items-center gap-2 border-t px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
                 >
                     <input
-                        value={inputValue}
-                        onChange={(e) => setInputValue(e.target.value)}
+                        value={inputDraft}
+                        onChange={(e) => setInputDraft(e.target.value)}
                         placeholder="Type your message..."
                         className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     />

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -144,10 +144,10 @@ export function ChatWidget() {
                         >
                             <div
                                 className={cn(
-                                    "max-w-[80%] rounded-lg px-3 py-2 text-sm",
+                                    "max-w-[80%] rounded-xl px-3 py-2 text-sm shadow-sm",
                                     message.sender === "user"
                                         ? "bg-primary text-primary-foreground"
-                                        : "bg-muted text-muted-foreground"
+                                        : "bg-gradient-to-br from-muted to-background text-foreground border border-border"
                                 )}
                             >
                                 <ReactMarkdown

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -45,13 +45,46 @@ const markdownComponents: Components = {
 };
 
 export function ChatWidget() {
-    const { messages, addMessage, isResponding, setIsResponding, inputDraft, setInputDraft } =
-        useChatStore();
+    const {
+        messages,
+        addMessage,
+        isResponding,
+        setIsResponding,
+        inputDraft,
+        setInputDraft,
+        isChatOpen,
+        scrollPosition,
+        setScrollPosition,
+    } = useChatStore();
     const endRef = useRef<HTMLDivElement | null>(null);
+    const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+    const previousOpenStateRef = useRef(isChatOpen);
 
     useEffect(() => {
         endRef.current?.scrollIntoView({ behavior: "smooth" });
     }, [messages]);
+
+    useEffect(() => {
+        if (!isChatOpen && scrollContainerRef.current) {
+            setScrollPosition(scrollContainerRef.current.scrollTop);
+        }
+    }, [isChatOpen, setScrollPosition]);
+
+    useEffect(() => {
+        if (isChatOpen && !previousOpenStateRef.current && scrollContainerRef.current) {
+            const container = scrollContainerRef.current;
+            requestAnimationFrame(() => {
+                container.scrollTop = scrollPosition;
+            });
+        }
+        previousOpenStateRef.current = isChatOpen;
+    }, [isChatOpen, scrollPosition]);
+
+    const handleScroll = () => {
+        if (scrollContainerRef.current) {
+            setScrollPosition(scrollContainerRef.current.scrollTop);
+        }
+    };
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -127,7 +160,11 @@ export function ChatWidget() {
             </div>
 
             <div className="flex h-full min-h-0 flex-col">
-                <div className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm">
+                <div
+                    ref={scrollContainerRef}
+                    onScroll={handleScroll}
+                    className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm"
+                >
                     {messages.map((message) => (
                         <div
                             key={message.id}

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -60,7 +60,6 @@ export function ChatWidget() {
     } = useChatStore();
     const endRef = useRef<HTMLDivElement | null>(null);
     const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-    const previousOpenStateRef = useRef(isChatOpen);
     const previousMessageCountRef = useRef(messages.length);
 
     useEffect(() => {
@@ -70,22 +69,26 @@ export function ChatWidget() {
         previousMessageCountRef.current = messages.length;
     }, [messages, isAtBottom]);
 
+    useLayoutEffect(() => {
+        if (!isChatOpen || !scrollContainerRef.current) return;
+
+        const container = scrollContainerRef.current;
+        if (Math.abs(container.scrollTop - scrollPosition) > 1) {
+            container.scrollTop = scrollPosition;
+        }
+
+        const { scrollHeight, clientHeight, scrollTop } = container;
+        const atBottom = scrollHeight - (scrollTop + clientHeight) < 8;
+        if (atBottom !== isAtBottom) {
+            setIsAtBottom(atBottom);
+        }
+    }, [isChatOpen, scrollPosition, isAtBottom, setIsAtBottom]);
+
     useEffect(() => {
         if (!isChatOpen && scrollContainerRef.current) {
             setScrollPosition(scrollContainerRef.current.scrollTop);
         }
     }, [isChatOpen, setScrollPosition]);
-
-    useLayoutEffect(() => {
-        if (isChatOpen && !previousOpenStateRef.current && scrollContainerRef.current) {
-            const container = scrollContainerRef.current;
-            container.scrollTop = scrollPosition;
-            const { scrollHeight, clientHeight, scrollTop } = container;
-            const atBottom = scrollHeight - (scrollTop + clientHeight) < 8;
-            setIsAtBottom(atBottom);
-        }
-        previousOpenStateRef.current = isChatOpen;
-    }, [isChatOpen, scrollPosition, setIsAtBottom]);
 
     const handleScroll = () => {
         if (scrollContainerRef.current) {

--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useRef, type HTMLAttributes } from "react";
+import { FormEvent, useEffect, useLayoutEffect, useRef, type HTMLAttributes } from "react";
 import { Button } from "@/components/ui/button";
 import { SheetClose } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
@@ -76,15 +76,13 @@ export function ChatWidget() {
         }
     }, [isChatOpen, setScrollPosition]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (isChatOpen && !previousOpenStateRef.current && scrollContainerRef.current) {
             const container = scrollContainerRef.current;
-            requestAnimationFrame(() => {
-                container.scrollTop = scrollPosition;
-                const { scrollHeight, clientHeight, scrollTop } = container;
-                const atBottom = scrollHeight - (scrollTop + clientHeight) < 8;
-                setIsAtBottom(atBottom);
-            });
+            container.scrollTop = scrollPosition;
+            const { scrollHeight, clientHeight, scrollTop } = container;
+            const atBottom = scrollHeight - (scrollTop + clientHeight) < 8;
+            setIsAtBottom(atBottom);
         }
         previousOpenStateRef.current = isChatOpen;
     }, [isChatOpen, scrollPosition, setIsAtBottom]);

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -34,7 +34,7 @@ export default function Navbar({
     const theme = useThemeStore((state) => state.theme);
     const setTheme = useThemeStore((state) => state.setTheme);
     const toggleTheme = useThemeStore((state) => state.toggleTheme);
-    const { hasUnread, setHasUnread } = useChatStore();
+    const { hasUnread, setHasUnread, setIsChatOpen: setChatStoreOpen } = useChatStore();
     const [mounted, setMounted] = useState(false);
     const [isChatOpen, setIsChatOpen] = useState(false);
 
@@ -110,6 +110,7 @@ export default function Navbar({
                         modal={false}
                         onOpenChange={(open) => {
                             setIsChatOpen(open);
+                            setChatStoreOpen(open);
                             if (open) setHasUnread(false);
                         }}
                     >
@@ -122,7 +123,7 @@ export default function Navbar({
                             >
                                 <MessageCircle className="h-5 w-5" />
                                 {hasUnread && !isChatOpen && (
-                                    <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary shadow-[0_0_8px_2px_rgba(var(--primary-rgb),0.5)]" />
+                                    <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_10px_2px_rgba(16,185,129,0.55)]" />
                                 )}
                             </Button>
                         </SheetTrigger>

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -107,7 +107,6 @@ export default function Navbar({
 
                 <div className="flex items-center gap-2">
                     <Sheet
-                        modal={false}
                         onOpenChange={(open) => {
                             setIsChatOpen(open);
                             setChatStoreOpen(open);

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -11,11 +11,13 @@ type ChatState = {
     isResponding: boolean;
     hasUnread: boolean;
     isChatOpen: boolean;
+    inputDraft: string;
     setMessages: (messages: Message[]) => void;
     addMessage: (message: Message) => void;
     setIsResponding: (state: boolean) => void;
     setHasUnread: (state: boolean) => void;
     setIsChatOpen: (state: boolean) => void;
+    setInputDraft: (value: string) => void;
     resetMessages: () => void;
 };
 
@@ -30,6 +32,7 @@ export const useChatStore = create<ChatState>((set) => ({
     isResponding: false,
     hasUnread: false,
     isChatOpen: false,
+    inputDraft: "",
     setMessages: (messages) => set({ messages }),
     addMessage: (message) =>
         set((state) => ({
@@ -44,5 +47,6 @@ export const useChatStore = create<ChatState>((set) => ({
             isChatOpen: state,
             hasUnread: state ? false : prevState.hasUnread,
         })),
-    resetMessages: () => set({ messages: [initialMessage], hasUnread: false }),
+    setInputDraft: (value) => set({ inputDraft: value }),
+    resetMessages: () => set({ messages: [initialMessage], hasUnread: false, inputDraft: "" }),
 }));

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -10,10 +10,12 @@ type ChatState = {
     messages: Message[];
     isResponding: boolean;
     hasUnread: boolean;
+    isChatOpen: boolean;
     setMessages: (messages: Message[]) => void;
     addMessage: (message: Message) => void;
     setIsResponding: (state: boolean) => void;
     setHasUnread: (state: boolean) => void;
+    setIsChatOpen: (state: boolean) => void;
     resetMessages: () => void;
 };
 
@@ -27,13 +29,20 @@ export const useChatStore = create<ChatState>((set) => ({
     messages: [initialMessage],
     isResponding: false,
     hasUnread: false,
+    isChatOpen: false,
     setMessages: (messages) => set({ messages }),
     addMessage: (message) =>
         set((state) => ({
             messages: [...state.messages, message],
-            hasUnread: message.sender === "bot" ? true : state.hasUnread,
+            hasUnread:
+                message.sender === "bot" && !state.isChatOpen ? true : state.hasUnread,
         })),
     setIsResponding: (state) => set({ isResponding: state }),
     setHasUnread: (state) => set({ hasUnread: state }),
+    setIsChatOpen: (state) =>
+        set((prevState) => ({
+            isChatOpen: state,
+            hasUnread: state ? false : prevState.hasUnread,
+        })),
     resetMessages: () => set({ messages: [initialMessage], hasUnread: false }),
 }));

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -13,6 +13,7 @@ type ChatState = {
     isChatOpen: boolean;
     inputDraft: string;
     scrollPosition: number;
+    isAtBottom: boolean;
     setMessages: (messages: Message[]) => void;
     addMessage: (message: Message) => void;
     setIsResponding: (state: boolean) => void;
@@ -20,6 +21,7 @@ type ChatState = {
     setIsChatOpen: (state: boolean) => void;
     setInputDraft: (value: string) => void;
     setScrollPosition: (value: number) => void;
+    setIsAtBottom: (value: boolean) => void;
     resetMessages: () => void;
 };
 
@@ -36,6 +38,7 @@ export const useChatStore = create<ChatState>((set) => ({
     isChatOpen: false,
     inputDraft: "",
     scrollPosition: 0,
+    isAtBottom: true,
     setMessages: (messages) => set({ messages }),
     addMessage: (message) =>
         set((state) => ({
@@ -52,6 +55,13 @@ export const useChatStore = create<ChatState>((set) => ({
         })),
     setInputDraft: (value) => set({ inputDraft: value }),
     setScrollPosition: (value) => set({ scrollPosition: value }),
+    setIsAtBottom: (value) => set({ isAtBottom: value }),
     resetMessages: () =>
-        set({ messages: [initialMessage], hasUnread: false, inputDraft: "", scrollPosition: 0 }),
+        set({
+            messages: [initialMessage],
+            hasUnread: false,
+            inputDraft: "",
+            scrollPosition: 0,
+            isAtBottom: true,
+        }),
 }));

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -12,12 +12,14 @@ type ChatState = {
     hasUnread: boolean;
     isChatOpen: boolean;
     inputDraft: string;
+    scrollPosition: number;
     setMessages: (messages: Message[]) => void;
     addMessage: (message: Message) => void;
     setIsResponding: (state: boolean) => void;
     setHasUnread: (state: boolean) => void;
     setIsChatOpen: (state: boolean) => void;
     setInputDraft: (value: string) => void;
+    setScrollPosition: (value: number) => void;
     resetMessages: () => void;
 };
 
@@ -33,6 +35,7 @@ export const useChatStore = create<ChatState>((set) => ({
     hasUnread: false,
     isChatOpen: false,
     inputDraft: "",
+    scrollPosition: 0,
     setMessages: (messages) => set({ messages }),
     addMessage: (message) =>
         set((state) => ({
@@ -48,5 +51,7 @@ export const useChatStore = create<ChatState>((set) => ({
             hasUnread: state ? false : prevState.hasUnread,
         })),
     setInputDraft: (value) => set({ inputDraft: value }),
-    resetMessages: () => set({ messages: [initialMessage], hasUnread: false, inputDraft: "" }),
+    setScrollPosition: (value) => set({ scrollPosition: value }),
+    resetMessages: () =>
+        set({ messages: [initialMessage], hasUnread: false, inputDraft: "", scrollPosition: 0 }),
 }));


### PR DESCRIPTION
## Summary
- enhance the bot response bubble with a softer gradient background and improved contrast
- update the chat notification indicator color and glow for better visibility
- add chat open state tracking so unread badges only appear when the assistant replies while the widget is closed

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116e72e4788327be0d0fa2df50905d)