### PR TITLE
Center navbar logo on small screens

### DIFF
--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -47,7 +47,7 @@ export default function Navbar({
 
     return (
         <header className="sticky top-0 z-40 w-full bg-card backdrop-blur">
-            <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+            <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 relative">
                 {/* Mobile Menu */}
                 <div className="md:hidden">
                     <Sheet>
@@ -78,7 +78,10 @@ export default function Navbar({
                 </div>
 
                 {/* Logo */}
-                <Link href="/" className="flex items-center gap-2 font-semibold">
+                <Link
+                    href="/"
+                    className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 font-semibold md:relative md:left-0 md:translate-x-0"
+                >
                     <div className="relative h-6 w-6">
                         <Image
                             src="/logo-dark.svg"


### PR DESCRIPTION
## Summary
- add relative positioning to the navbar container so the logo can be centered on small screens
- absolutely center the logo link on mobile while keeping the existing desktop layout

## Testing
- npm run lint *(fails: ESLint could not resolve @eslint/eslintrc after npm install errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69129826481083278cc4e4351f5f97c4)