### PR TITLE
Add fullscreen and minimize controls for chat assistant

### DIFF
--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -4,7 +4,7 @@ import { FormEvent, useEffect, useLayoutEffect, useRef, type HTMLAttributes } fr
 import { Button } from "@/components/ui/button";
 import { SheetClose } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
-import { SendHorizontal, X } from "lucide-react";
+import { Maximize2, Minimize2, Minus, SendHorizontal, Square, X } from "lucide-react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useChatStore } from "@/lib/chat-store";
@@ -57,6 +57,10 @@ export function ChatWidget() {
         setScrollPosition,
         isAtBottom,
         setIsAtBottom,
+        isFullscreen,
+        setIsFullscreen,
+        isMinimized,
+        setIsMinimized,
     } = useChatStore();
     const endRef = useRef<HTMLDivElement | null>(null);
     const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -70,7 +74,7 @@ export function ChatWidget() {
     }, [messages, isAtBottom]);
 
     useLayoutEffect(() => {
-        if (!isChatOpen || !scrollContainerRef.current) return;
+        if (!isChatOpen || !scrollContainerRef.current || isMinimized) return;
 
         const container = scrollContainerRef.current;
         if (Math.abs(container.scrollTop - scrollPosition) > 1) {
@@ -82,22 +86,35 @@ export function ChatWidget() {
         if (atBottom !== isAtBottom) {
             setIsAtBottom(atBottom);
         }
-    }, [isChatOpen, scrollPosition, isAtBottom, setIsAtBottom]);
+    }, [isChatOpen, scrollPosition, isAtBottom, setIsAtBottom, isMinimized]);
 
     useEffect(() => {
-        if (!isChatOpen && scrollContainerRef.current) {
+        if ((!isChatOpen || isMinimized) && scrollContainerRef.current) {
             setScrollPosition(scrollContainerRef.current.scrollTop);
         }
-    }, [isChatOpen, setScrollPosition]);
+    }, [isChatOpen, isMinimized, setScrollPosition]);
+
+    useEffect(() => {
+        if (!isMinimized || !scrollContainerRef.current) return;
+        setScrollPosition(scrollContainerRef.current.scrollTop);
+    }, [isMinimized, setScrollPosition]);
 
     const handleScroll = () => {
-        if (scrollContainerRef.current) {
+        if (scrollContainerRef.current && !isMinimized) {
             const container = scrollContainerRef.current;
             const { scrollTop, scrollHeight, clientHeight } = container;
             const isNearBottom = scrollHeight - (scrollTop + clientHeight) < 8;
             setScrollPosition(scrollTop);
             setIsAtBottom(isNearBottom);
         }
+    };
+
+    const handleToggleFullscreen = () => {
+        setIsFullscreen(!isFullscreen);
+    };
+
+    const handleToggleMinimize = () => {
+        setIsMinimized(!isMinimized);
     };
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -153,24 +170,58 @@ export function ChatWidget() {
     };
 
     return (
-        <div className="flex h-full min-h-0 flex-1 flex-col">
+        <div
+            className={cn(
+                "flex min-h-0 flex-1 flex-col",
+                isMinimized ? "h-auto flex-none" : "h-full"
+            )}
+        >
             <div
                 className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur"
                 style={{ paddingTop: "env(safe-area-inset-top)" }}
             >
                 <div className="relative flex items-center justify-center px-4 py-3 text-sm font-semibold">
                     <span>Chat Assistant</span>
-                    <SheetClose asChild>
+                    <div className="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1">
                         <Button
                             type="button"
                             variant="ghost"
                             size="icon"
-                            className="absolute right-2.5 top-1/2 -translate-y-1/2"
-                            aria-label="Close chat assistant"
+                            className="hidden lg:flex"
+                            onClick={handleToggleFullscreen}
+                            aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
                         >
-                            <X className="h-4 w-4" />
+                            {isFullscreen ? (
+                                <Minimize2 className="h-4 w-4" />
+                            ) : (
+                                <Maximize2 className="h-4 w-4" />
+                            )}
                         </Button>
-                    </SheetClose>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="hidden lg:flex"
+                            onClick={handleToggleMinimize}
+                            aria-label={isMinimized ? "Restore chat" : "Minimize chat"}
+                        >
+                            {isMinimized ? (
+                                <Square className="h-4 w-4" />
+                            ) : (
+                                <Minus className="h-4 w-4" />
+                            )}
+                        </Button>
+                        <SheetClose asChild>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                aria-label="Close chat assistant"
+                            >
+                                <X className="h-4 w-4" />
+                            </Button>
+                        </SheetClose>
+                    </div>
                 </div>
             </div>
 
@@ -178,7 +229,10 @@ export function ChatWidget() {
                 <div
                     ref={scrollContainerRef}
                     onScroll={handleScroll}
-                    className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm"
+                    className={cn(
+                        "flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm",
+                        isMinimized && "hidden"
+                    )}
                 >
                     {messages.map((message) => (
                         <div
@@ -216,7 +270,10 @@ export function ChatWidget() {
 
                 <form
                     onSubmit={handleSubmit}
-                    className="flex items-center gap-2 border-t px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
+                    className={cn(
+                        "flex items-center gap-2 border-t px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]",
+                        isMinimized && "hidden"
+                    )}
                 >
                     <input
                         value={inputDraft}

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -17,6 +17,7 @@ import { useThemeStore } from "@/lib/theme-store";
 import { Separator } from "@/components/ui/separator";
 import { ChatWidget } from "@/components/ui/chat-widget";
 import { useChatStore } from "@/lib/chat-store";
+import { cn } from "@/lib/utils";
 
 const links = [
     { href: "#about", label: "About" },
@@ -34,7 +35,13 @@ export default function Navbar({
     const theme = useThemeStore((state) => state.theme);
     const setTheme = useThemeStore((state) => state.setTheme);
     const toggleTheme = useThemeStore((state) => state.toggleTheme);
-    const { hasUnread, setHasUnread, setIsChatOpen: setChatStoreOpen } = useChatStore();
+    const {
+        hasUnread,
+        setHasUnread,
+        setIsChatOpen: setChatStoreOpen,
+        isFullscreen,
+        isMinimized,
+    } = useChatStore();
     const [mounted, setMounted] = useState(false);
     const [isChatOpen, setIsChatOpen] = useState(false);
 
@@ -133,21 +140,28 @@ export default function Navbar({
                         <SheetContent
                             forceMount
                             side="right"
-                            className="flex h-[100dvh] w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:h-full sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden"
-                            style={{
-                                height: "100dvh",
-                                maxHeight: "100dvh",
-                                minHeight: "100svh",
-                            }}
+                            className={cn(
+                                "flex w-screen max-w-full flex-col gap-0 overflow-hidden p-0 [&>button[data-radix-dialog-close]]:hidden",
+                                isFullscreen ? "sm:max-w-full lg:max-w-none" : "sm:max-w-md",
+                                isFullscreen && "sm:rounded-none",
+                                isMinimized ? "h-auto min-h-0" : "h-[100dvh] sm:h-full"
+                            )}
+                            style={
+                                isMinimized
+                                    ? undefined
+                                    : {
+                                          height: "100dvh",
+                                          maxHeight: "100dvh",
+                                          minHeight: "100svh",
+                                      }
+                            }
                         >
                             <SheetTitle className="sr-only">Chat Assistant</SheetTitle>
                             <SheetDescription className="sr-only">
                                 Start a conversation with the portfolio assistant
                             </SheetDescription>
 
-                            <div className="absolute inset-0">
-                                <ChatWidget />
-                            </div>
+                            <ChatWidget />
                         </SheetContent>
                     </Sheet>
 

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -11,6 +11,8 @@ type ChatState = {
     isResponding: boolean;
     hasUnread: boolean;
     isChatOpen: boolean;
+    isFullscreen: boolean;
+    isMinimized: boolean;
     inputDraft: string;
     scrollPosition: number;
     isAtBottom: boolean;
@@ -19,6 +21,8 @@ type ChatState = {
     setIsResponding: (state: boolean) => void;
     setHasUnread: (state: boolean) => void;
     setIsChatOpen: (state: boolean) => void;
+    setIsFullscreen: (state: boolean) => void;
+    setIsMinimized: (state: boolean) => void;
     setInputDraft: (value: string) => void;
     setScrollPosition: (value: number) => void;
     setIsAtBottom: (value: boolean) => void;
@@ -36,6 +40,8 @@ export const useChatStore = create<ChatState>((set) => ({
     isResponding: false,
     hasUnread: false,
     isChatOpen: false,
+    isFullscreen: false,
+    isMinimized: false,
     inputDraft: "",
     scrollPosition: 0,
     isAtBottom: true,
@@ -52,6 +58,18 @@ export const useChatStore = create<ChatState>((set) => ({
         set((prevState) => ({
             isChatOpen: state,
             hasUnread: state ? false : prevState.hasUnread,
+            isFullscreen: state ? prevState.isFullscreen : false,
+            isMinimized: state ? prevState.isMinimized : false,
+        })),
+    setIsFullscreen: (state) =>
+        set((prevState) => ({
+            isFullscreen: state,
+            isMinimized: state ? false : prevState.isMinimized,
+        })),
+    setIsMinimized: (state) =>
+        set((prevState) => ({
+            isMinimized: state,
+            isFullscreen: state ? false : prevState.isFullscreen,
         })),
     setInputDraft: (value) => set({ inputDraft: value }),
     setScrollPosition: (value) => set({ scrollPosition: value }),
@@ -60,6 +78,8 @@ export const useChatStore = create<ChatState>((set) => ({
         set({
             messages: [initialMessage],
             hasUnread: false,
+            isFullscreen: false,
+            isMinimized: false,
             inputDraft: "",
             scrollPosition: 0,
             isAtBottom: true,


### PR DESCRIPTION
## Summary
- add fullscreen and minimize controls to the chat widget header on large screens
- extend the chat store with view-state flags and update the navbar sheet to react to them
- hide the conversation body and composer when minimized and keep layout stable in fullscreen

## Testing
- `npm run lint` *(fails: missing @eslint/eslintrc package in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bdbd90708327988e2da076f12747)