### PR TITLE
Add fullscreen and minimize controls to chat assistant

### DIFF
--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -4,7 +4,7 @@ import { FormEvent, useEffect, useLayoutEffect, useRef, type HTMLAttributes } fr
 import { Button } from "@/components/ui/button";
 import { SheetClose } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
-import { SendHorizontal, X } from "lucide-react";
+import { Maximize2, Minimize2, Minus, SendHorizontal, Square, X } from "lucide-react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useChatStore } from "@/lib/chat-store";
@@ -57,6 +57,10 @@ export function ChatWidget() {
         setScrollPosition,
         isAtBottom,
         setIsAtBottom,
+        isFullscreen,
+        setIsFullscreen,
+        isMinimized,
+        setIsMinimized,
     } = useChatStore();
     const endRef = useRef<HTMLDivElement | null>(null);
     const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -152,83 +156,130 @@ export function ChatWidget() {
             .finally(() => setIsResponding(false));
     };
 
+    const handleToggleFullscreen = () => {
+        if (!isFullscreen) {
+            setIsMinimized(false);
+        }
+        setIsFullscreen(!isFullscreen);
+    };
+
+    const handleToggleMinimized = () => {
+        if (!isMinimized) {
+            setIsFullscreen(false);
+        }
+        setIsMinimized(!isMinimized);
+    };
+
     return (
-        <div className="flex h-full min-h-0 flex-1 flex-col">
+        <div
+            className={cn(
+                "flex h-full min-h-0 flex-1 flex-col",
+                isFullscreen && "sm:fixed sm:inset-0 sm:z-50 sm:bg-background sm:p-0",
+                isMinimized && "sm:h-auto"
+            )}
+        >
             <div
                 className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur"
                 style={{ paddingTop: "env(safe-area-inset-top)" }}
             >
                 <div className="relative flex items-center justify-center px-4 py-3 text-sm font-semibold">
                     <span>Chat Assistant</span>
-                    <SheetClose asChild>
+                    <div className="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1">
                         <Button
                             type="button"
                             variant="ghost"
                             size="icon"
-                            className="absolute right-2.5 top-1/2 -translate-y-1/2"
-                            aria-label="Close chat assistant"
+                            className="hidden md:inline-flex"
+                            onClick={handleToggleMinimized}
+                            aria-label={isMinimized ? "Restore chat assistant" : "Minimize chat assistant"}
                         >
-                            <X className="h-4 w-4" />
+                            {isMinimized ? <Square className="h-4 w-4" /> : <Minus className="h-4 w-4" />}
                         </Button>
-                    </SheetClose>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="hidden md:inline-flex"
+                            onClick={handleToggleFullscreen}
+                            aria-label={isFullscreen ? "Exit full screen" : "Enter full screen"}
+                        >
+                            {isFullscreen ? (
+                                <Minimize2 className="h-4 w-4" />
+                            ) : (
+                                <Maximize2 className="h-4 w-4" />
+                            )}
+                        </Button>
+                        <SheetClose asChild>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                aria-label="Close chat assistant"
+                            >
+                                <X className="h-4 w-4" />
+                            </Button>
+                        </SheetClose>
+                    </div>
                 </div>
             </div>
 
-            <div className="flex h-full min-h-0 flex-col">
-                <div
-                    ref={scrollContainerRef}
-                    onScroll={handleScroll}
-                    className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm"
-                >
-                    {messages.map((message) => (
-                        <div
-                            key={message.id}
-                            className={cn(
-                                "flex",
-                                message.sender === "user" ? "justify-end" : "justify-start"
-                            )}
-                        >
+            {!isMinimized && (
+                <div className="flex h-full min-h-0 flex-col">
+                    <div
+                        ref={scrollContainerRef}
+                        onScroll={handleScroll}
+                        className="flex-1 min-h-0 space-y-3 overflow-y-auto px-4 py-3 text-sm"
+                    >
+                        {messages.map((message) => (
                             <div
+                                key={message.id}
                                 className={cn(
-                                    "max-w-[80%] rounded-xl px-3 py-2 text-sm shadow-sm",
-                                    message.sender === "user"
-                                        ? "bg-primary text-primary-foreground"
-                                        : "bg-gradient-to-br from-muted to-background text-foreground border border-border"
+                                    "flex",
+                                    message.sender === "user" ? "justify-end" : "justify-start"
                                 )}
                             >
-                                <ReactMarkdown
-                                    remarkPlugins={[remarkGfm]}
-                                    components={markdownComponents}
-                                    className="space-y-2"
+                                <div
+                                    className={cn(
+                                        "max-w-[80%] rounded-xl px-3 py-2 text-sm shadow-sm",
+                                        message.sender === "user"
+                                            ? "bg-primary text-primary-foreground"
+                                            : "bg-gradient-to-br from-muted to-background text-foreground border border-border"
+                                    )}
                                 >
-                                    {message.text}
-                                </ReactMarkdown>
+                                    <ReactMarkdown
+                                        remarkPlugins={[remarkGfm]}
+                                        components={markdownComponents}
+                                        className="space-y-2"
+                                    >
+                                        {message.text}
+                                    </ReactMarkdown>
+                                </div>
                             </div>
-                        </div>
-                    ))}
-                    {isResponding && (
-                        <div className="text-xs text-muted-foreground">
-                            The assistant is typing...
-                        </div>
-                    )}
-                    <div ref={endRef} />
-                </div>
+                        ))}
+                        {isResponding && (
+                            <div className="text-xs text-muted-foreground">
+                                The assistant is typing...
+                            </div>
+                        )}
+                        <div ref={endRef} />
+                    </div>
 
-                <form
-                    onSubmit={handleSubmit}
-                    className="flex items-center gap-2 border-t px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
-                >
-                    <input
-                        value={inputDraft}
-                        onChange={(e) => setInputDraft(e.target.value)}
-                        placeholder="Type your message..."
-                        className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    />
-                    <Button type="submit" size="icon" disabled={isResponding}>
-                        <SendHorizontal className="h-4 w-4" />
-                    </Button>
-                </form>
-            </div>
+                    <form
+                        onSubmit={handleSubmit}
+                        className="flex items-center gap-2 border-t px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)]"
+                    >
+                        <input
+                            value={inputDraft}
+                            onChange={(e) => setInputDraft(e.target.value)}
+                            placeholder="Type your message..."
+                            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        />
+                        <Button type="submit" size="icon" disabled={isResponding}>
+                            <SendHorizontal className="h-4 w-4" />
+                        </Button>
+                    </form>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -17,6 +17,7 @@ import { useThemeStore } from "@/lib/theme-store";
 import { Separator } from "@/components/ui/separator";
 import { ChatWidget } from "@/components/ui/chat-widget";
 import { useChatStore } from "@/lib/chat-store";
+import { cn } from "@/lib/utils";
 
 const links = [
     { href: "#about", label: "About" },
@@ -34,7 +35,14 @@ export default function Navbar({
     const theme = useThemeStore((state) => state.theme);
     const setTheme = useThemeStore((state) => state.setTheme);
     const toggleTheme = useThemeStore((state) => state.toggleTheme);
-    const { hasUnread, setHasUnread, setIsChatOpen: setChatStoreOpen } = useChatStore();
+    const {
+        hasUnread,
+        setHasUnread,
+        setIsChatOpen: setChatStoreOpen,
+        isFullscreen,
+        isMinimized,
+        resetLayout,
+    } = useChatStore();
     const [mounted, setMounted] = useState(false);
     const [isChatOpen, setIsChatOpen] = useState(false);
 
@@ -113,7 +121,10 @@ export default function Navbar({
                         onOpenChange={(open) => {
                             setIsChatOpen(open);
                             setChatStoreOpen(open);
-                            if (open) setHasUnread(false);
+                            if (open) {
+                                setHasUnread(false);
+                            }
+                            resetLayout();
                         }}
                     >
                         <SheetTrigger asChild>
@@ -133,11 +144,15 @@ export default function Navbar({
                         <SheetContent
                             forceMount
                             side="right"
-                            className="flex h-[100dvh] w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:h-full sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden"
+                            className={cn(
+                                "flex h-[100dvh] w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:h-full sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden",
+                                isFullscreen && "sm:h-screen sm:w-screen sm:max-w-none sm:rounded-none",
+                                isMinimized && "sm:h-auto sm:max-h-[4.5rem]"
+                            )}
                             style={{
-                                height: "100dvh",
-                                maxHeight: "100dvh",
-                                minHeight: "100svh",
+                                height: isMinimized ? undefined : "100dvh",
+                                maxHeight: isMinimized ? undefined : "100dvh",
+                                minHeight: isMinimized ? undefined : "100svh",
                             }}
                         >
                             <SheetTitle className="sr-only">Chat Assistant</SheetTitle>

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -11,6 +11,8 @@ type ChatState = {
     isResponding: boolean;
     hasUnread: boolean;
     isChatOpen: boolean;
+    isFullscreen: boolean;
+    isMinimized: boolean;
     inputDraft: string;
     scrollPosition: number;
     isAtBottom: boolean;
@@ -19,10 +21,13 @@ type ChatState = {
     setIsResponding: (state: boolean) => void;
     setHasUnread: (state: boolean) => void;
     setIsChatOpen: (state: boolean) => void;
+    setIsFullscreen: (state: boolean) => void;
+    setIsMinimized: (state: boolean) => void;
     setInputDraft: (value: string) => void;
     setScrollPosition: (value: number) => void;
     setIsAtBottom: (value: boolean) => void;
     resetMessages: () => void;
+    resetLayout: () => void;
 };
 
 const initialMessage: Message = {
@@ -36,6 +41,8 @@ export const useChatStore = create<ChatState>((set) => ({
     isResponding: false,
     hasUnread: false,
     isChatOpen: false,
+    isFullscreen: false,
+    isMinimized: false,
     inputDraft: "",
     scrollPosition: 0,
     isAtBottom: true,
@@ -53,6 +60,8 @@ export const useChatStore = create<ChatState>((set) => ({
             isChatOpen: state,
             hasUnread: state ? false : prevState.hasUnread,
         })),
+    setIsFullscreen: (state) => set({ isFullscreen: state }),
+    setIsMinimized: (state) => set({ isMinimized: state }),
     setInputDraft: (value) => set({ inputDraft: value }),
     setScrollPosition: (value) => set({ scrollPosition: value }),
     setIsAtBottom: (value) => set({ isAtBottom: value }),
@@ -64,4 +73,5 @@ export const useChatStore = create<ChatState>((set) => ({
             scrollPosition: 0,
             isAtBottom: true,
         }),
+    resetLayout: () => set({ isFullscreen: false, isMinimized: false }),
 }));


### PR DESCRIPTION
## Summary
- add desktop-only minimize and fullscreen controls to the chat widget header
- store fullscreen/minimized state in the chat store with a reset helper
- adapt the chat sheet container to honor fullscreen and minimized layouts

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bdbd90708327988e2da076f12747)