### PR TITLE
Add fullscreen and minimize controls to chat assistant

### DIFF
--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -17,6 +17,7 @@ import { useThemeStore } from "@/lib/theme-store";
 import { Separator } from "@/components/ui/separator";
 import { ChatWidget } from "@/components/ui/chat-widget";
 import { useChatStore } from "@/lib/chat-store";
+import { cn } from "@/lib/utils";
 
 const links = [
     { href: "#about", label: "About" },
@@ -34,7 +35,15 @@ export default function Navbar({
     const theme = useThemeStore((state) => state.theme);
     const setTheme = useThemeStore((state) => state.setTheme);
     const toggleTheme = useThemeStore((state) => state.toggleTheme);
-    const { hasUnread, setHasUnread, setIsChatOpen: setChatStoreOpen } = useChatStore();
+    const {
+        hasUnread,
+        setHasUnread,
+        setIsChatOpen: setChatStoreOpen,
+        isFullscreen,
+        isMinimized,
+        setIsFullscreen,
+        setIsMinimized,
+    } = useChatStore();
     const [mounted, setMounted] = useState(false);
     const [isChatOpen, setIsChatOpen] = useState(false);
 
@@ -113,7 +122,12 @@ export default function Navbar({
                         onOpenChange={(open) => {
                             setIsChatOpen(open);
                             setChatStoreOpen(open);
-                            if (open) setHasUnread(false);
+                            if (!open) {
+                                setIsFullscreen(false);
+                                setIsMinimized(false);
+                            } else {
+                                setHasUnread(false);
+                            }
                         }}
                     >
                         <SheetTrigger asChild>
@@ -133,11 +147,15 @@ export default function Navbar({
                         <SheetContent
                             forceMount
                             side="right"
-                            className="flex h-[100dvh] w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:h-full sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden"
+                            className={cn(
+                                "flex w-screen max-w-full flex-col gap-0 overflow-hidden p-0 sm:w-full sm:max-w-md [&>button[data-radix-dialog-close]]:hidden",
+                                isMinimized ? "h-auto" : "h-[100dvh] sm:h-full",
+                                isFullscreen && "sm:max-w-full md:h-[100dvh] md:w-screen md:rounded-none"
+                            )}
                             style={{
-                                height: "100dvh",
-                                maxHeight: "100dvh",
-                                minHeight: "100svh",
+                                height: isMinimized ? undefined : "100dvh",
+                                maxHeight: isMinimized ? undefined : "100dvh",
+                                minHeight: isMinimized ? undefined : "100svh",
                             }}
                         >
                             <SheetTitle className="sr-only">Chat Assistant</SheetTitle>

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -11,6 +11,8 @@ type ChatState = {
     isResponding: boolean;
     hasUnread: boolean;
     isChatOpen: boolean;
+    isFullscreen: boolean;
+    isMinimized: boolean;
     inputDraft: string;
     scrollPosition: number;
     isAtBottom: boolean;
@@ -19,6 +21,8 @@ type ChatState = {
     setIsResponding: (state: boolean) => void;
     setHasUnread: (state: boolean) => void;
     setIsChatOpen: (state: boolean) => void;
+    setIsFullscreen: (state: boolean) => void;
+    setIsMinimized: (state: boolean) => void;
     setInputDraft: (value: string) => void;
     setScrollPosition: (value: number) => void;
     setIsAtBottom: (value: boolean) => void;
@@ -36,6 +40,8 @@ export const useChatStore = create<ChatState>((set) => ({
     isResponding: false,
     hasUnread: false,
     isChatOpen: false,
+    isFullscreen: false,
+    isMinimized: false,
     inputDraft: "",
     scrollPosition: 0,
     isAtBottom: true,
@@ -52,7 +58,11 @@ export const useChatStore = create<ChatState>((set) => ({
         set((prevState) => ({
             isChatOpen: state,
             hasUnread: state ? false : prevState.hasUnread,
+            isFullscreen: state ? prevState.isFullscreen : false,
+            isMinimized: state ? prevState.isMinimized : false,
         })),
+    setIsFullscreen: (state) => set({ isFullscreen: state }),
+    setIsMinimized: (state) => set({ isMinimized: state }),
     setInputDraft: (value) => set({ inputDraft: value }),
     setScrollPosition: (value) => set({ scrollPosition: value }),
     setIsAtBottom: (value) => set({ isAtBottom: value }),


### PR DESCRIPTION
## Summary
- add fullscreen and minimized layout state to the chat store
- expose fullscreen and minimize controls in the chat widget header on larger screens
- update the sheet container to honour fullscreen and minimized layouts

## Testing
- npm run lint *(fails: missing dependency `@eslint/eslintrc`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bdbd90708327988e2da076f12747)