### PR TITLE
Remove gradient background from assistant messages

### DIFF
--- a/src/components/ui/chat-widget.tsx
+++ b/src/components/ui/chat-widget.tsx
@@ -209,7 +209,7 @@ export function ChatWidget() {
                   "max-w-[80%] rounded-xl px-3 py-2 text-sm shadow-sm",
                   message.sender === "user"
                     ? "bg-primary text-primary-foreground"
-                    : "bg-gradient-to-br from-muted to-background text-foreground border border-border"
+                    : "bg-muted text-foreground border border-border"
                 )}
               >
                 <ReactMarkdown


### PR DESCRIPTION
## Summary
- replace the assistant message background gradient with a muted solid color

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d1becae8832794b8108b4320d79c)