### PR TITLE
Include resume images in chat requests

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -51,10 +51,14 @@ type ChatRequestBody = {
     messages?: ChatMessage[]
 }
 
-const RESUME_IMAGE_PATHS = [
-    path.join(process.cwd(), "public", "assets", "resume_page_0001.jpg"),
-    path.join(process.cwd(), "public", "assets", "resume_page_0002.jpg"),
+const RESUME_IMAGE_FILENAMES = [
+    "resume_page-0001.jpg",
+    "resume_page-0002.jpg",
 ] as const
+
+const RESUME_IMAGE_PATHS = RESUME_IMAGE_FILENAMES.map((fileName) =>
+    path.join(process.cwd(), "public", "assets", fileName)
+) as readonly string[]
 
 const loadResumeImageParts = async (): Promise<GeminiImagePart[]> => {
     const images = await Promise.all(

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
 
 const MODEL_NAME = process.env.GEMINI_MODEL ?? "gemini-2.0-flash"
 const GENERATE_CONTENT_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL_NAME}:generateContent`
@@ -10,8 +12,18 @@ type ChatMessage = {
     content: string
 }
 
+type GeminiInlineData = {
+    mimeType: string
+    data: string
+}
+
 type GeminiPart = {
     text?: string
+    inlineData?: GeminiInlineData
+}
+
+type GeminiImagePart = {
+    inlineData: GeminiInlineData
 }
 
 type GeminiContent = {
@@ -39,10 +51,43 @@ type ChatRequestBody = {
     messages?: ChatMessage[]
 }
 
-const buildContents = (messages: ChatMessage[]): GeminiContent[] =>
+const RESUME_IMAGE_PATHS = [
+    path.join(process.cwd(), "public", "assets", "resume_page_0001.jpg"),
+    path.join(process.cwd(), "public", "assets", "resume_page_0002.jpg"),
+] as const
+
+const loadResumeImageParts = async (): Promise<GeminiImagePart[]> => {
+    const images = await Promise.all(
+        RESUME_IMAGE_PATHS.map(async (filePath) => {
+            const file = await fs.readFile(filePath)
+
+            return {
+                inlineData: {
+                    mimeType: "image/jpeg",
+                    data: file.toString("base64"),
+                },
+            }
+        })
+    )
+
+    return images
+}
+
+const buildContents = (
+    messages: ChatMessage[],
+    resumeImageParts: GeminiImagePart[]
+): GeminiContent[] =>
     messages.map((message) => ({
         role: message.role === "assistant" ? "model" : "user",
-        parts: [{ text: message.content }],
+        parts:
+            message.role === "assistant"
+                ? [{ text: message.content }]
+                : [
+                      ...resumeImageParts.map((part) => ({
+                          inlineData: { ...part.inlineData },
+                      })),
+                      { text: message.content },
+                  ],
     }))
 
 const extractReply = (payload: GeminiResponse): string | null => {
@@ -103,7 +148,20 @@ export async function POST(request: Request) {
         )
     }
 
-    const contents = buildContents(messages)
+    let resumeImageParts: GeminiImagePart[]
+
+    try {
+        resumeImageParts = await loadResumeImageParts()
+    } catch {
+        return NextResponse.json(
+            {
+                error: "Failed to load resume images required for the assistant context.",
+            },
+            { status: 500 }
+        )
+    }
+
+    const contents = buildContents(messages, resumeImageParts)
 
     try {
         const response = await fetch(`${GENERATE_CONTENT_ENDPOINT}?key=${apiKey}`, {
@@ -122,6 +180,8 @@ export async function POST(request: Request) {
                                 "Answer each question clearly and concisely using Markdown when it improves readability.",
                                 "If you do not know the answer, be honest and offer helpful suggestions for finding it.",
                                 "Keep responses welcoming and professional, and avoid fabricating details about the user.",
+                                "Each user message is accompanied by two images that contain the subject's resume. Use only information that is visible in these images when answering questions about the subject.",
+                                "If the requested information is not present or is unclear in the resume images, clearly state that you cannot confirm it.",
                             ].join("\n"),
                         },
                     ],


### PR DESCRIPTION
## Summary
- load the public resume images and attach them to every user message sent to Gemini
- instruct the assistant to rely on the resume imagery and acknowledge failures to load the files

## Testing
- npm run lint *(fails: Missing dependency '@eslint/eslintrc' in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ca6806b4832797de9f16dd7a67b1)