### PR TITLE
Replace react-icons with lucide-react icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "next": "15.5.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-icons": "^5.5.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.8",
@@ -5422,15 +5421,6 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-icons": "^5.5.0",
     "react-markdown": "^9.0.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -9,8 +9,7 @@ import {
     SheetTitle,
     SheetDescription,
 } from "@/components/ui/sheet";
-import { Menu, MessageCircle } from "lucide-react";
-import { FaMoon, FaSun } from "react-icons/fa";
+import { Menu, MessageCircle, Moon, Sun } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import { useThemeStore } from "@/lib/theme-store";
@@ -157,7 +156,11 @@ export default function Navbar({
                         className="size-8"
                         onClick={toggleTheme}
                     >
-                        {currentTheme === "dark" ? <FaSun /> : <FaMoon />}
+                        {currentTheme === "dark" ? (
+                            <Sun className="h-5 w-5" />
+                        ) : (
+                            <Moon className="h-5 w-5" />
+                        )}
                     </Button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the react-icons dependency from the project
- switch the navbar theme toggle to use lucide-react icons

## Testing
- not run (environment issue: npm install blocked by registry 403)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691412810b4c8327b1643a665464bfdf)